### PR TITLE
fix(tui): support Ctrl+V clipboard paste in TUI text input (#207)

### DIFF
--- a/src/cli/tui/hooks/__tests__/useTextInput.test.tsx
+++ b/src/cli/tui/hooks/__tests__/useTextInput.test.tsx
@@ -1,14 +1,18 @@
 import { findNextWordBoundary, findPrevWordBoundary, useTextInput } from '../useTextInput.js';
 import { Text } from 'ink';
 import { render } from 'ink-testing-library';
+import { spawnSync } from 'node:child_process';
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({ spawnSync: vi.fn() }));
 
 const ENTER = '\r';
 const ESCAPE = '\x1B';
 const BACKSPACE = '\x7f';
 const LEFT = '\x1B[D';
 const RIGHT = '\x1B[C';
+const CTRL_V = '\x16';
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -365,5 +369,42 @@ describe('useTextInput keyboard shortcuts', () => {
 
     expect(lastFrame()).toContain('val:[hello]');
     expect(lastFrame()).toContain('cur:5');
+  });
+
+  it('Ctrl+V pastes clipboard text at the cursor', async () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: 'pasted-secret-123' } as never);
+    const { lastFrame, stdin } = render(<TextInputHarness initialValue="ab" />);
+
+    await delay();
+    stdin.write(LEFT); // cursor at 1, between 'a' and 'b'
+    await delay();
+    stdin.write(CTRL_V);
+    await delay();
+
+    expect(lastFrame()).toContain('val:[apasted-secret-123b]');
+    expect(lastFrame()).toContain('cur:18'); // 1 + 'pasted-secret-123'.length
+  });
+
+  it('Ctrl+V strips control chars from pasted text', async () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 0, stdout: 'a\rb\x7fc' } as never);
+    const { lastFrame, stdin } = render(<TextInputHarness />);
+
+    await delay();
+    stdin.write(CTRL_V);
+    await delay();
+
+    expect(lastFrame()).toContain('val:[abc]');
+  });
+
+  it('Ctrl+V is a no-op (not a swallowed keystroke) when clipboard read fails', async () => {
+    vi.mocked(spawnSync).mockReturnValue({ status: 1, stdout: '' } as never);
+    const { lastFrame, stdin } = render(<TextInputHarness initialValue="keep" />);
+
+    await delay();
+    stdin.write(CTRL_V);
+    await delay();
+
+    expect(lastFrame()).toContain('val:[keep]');
+    expect(lastFrame()).toContain('cur:4');
   });
 });

--- a/src/cli/tui/hooks/useTextInput.ts
+++ b/src/cli/tui/hooks/useTextInput.ts
@@ -1,5 +1,28 @@
+import { isMacOS, isWindows } from '../../../lib/utils/platform';
 import { useInput } from 'ink';
+import { spawnSync } from 'node:child_process';
 import React, { useCallback, useState } from 'react';
+
+/**
+ * Synchronously read the OS clipboard so Ctrl+V works on consoles (e.g. classic Windows conhost)
+ * that pass the raw control byte to the app instead of injecting the clipboard text themselves.
+ * Mirrors the cross-platform clipboard-write in fetch-access's useFetchAccessFlow. Returns '' on
+ * any failure (missing tool, empty clipboard) so paste is a safe no-op.
+ */
+function readClipboard(): string {
+  const [cmd, args]: [string, string[]] = isWindows
+    ? ['powershell', ['-NoProfile', '-Command', 'Get-Clipboard']]
+    : isMacOS
+      ? ['pbpaste', []]
+      : ['xclip', ['-o', '-selection', 'clipboard']];
+  let result = spawnSync(cmd, args, { encoding: 'utf8' });
+  if (result.status !== 0 && !isWindows && !isMacOS) {
+    result = spawnSync('xsel', ['-b'], { encoding: 'utf8' });
+  }
+  if (result.status !== 0 || typeof result.stdout !== 'string') return '';
+  // Windows Get-Clipboard appends a trailing newline; trim it without touching interior content.
+  return isWindows ? result.stdout.replace(/\r?\n$/, '') : result.stdout;
+}
 
 /** Find the position of the previous word boundary */
 export function findPrevWordBoundary(text: string, cursor: number): number {
@@ -144,6 +167,21 @@ export function useTextInput({
       // Ctrl+K: delete to end
       if (key.ctrl && input === 'k') {
         setState(prev => ({ text: prev.text.slice(0, prev.cursor), cursor: prev.cursor }));
+        return;
+      }
+
+      // Ctrl+V: paste from OS clipboard (consoles that drop the raw control byte instead of
+      // injecting clipboard text themselves). Insert at cursor with the same control-char filtering
+      // as the regular-character branch below.
+      if (key.ctrl && input === 'v') {
+        // eslint-disable-next-line no-control-regex
+        const pasted = readClipboard().replace(/[\x7f\x08\r]/g, '');
+        if (pasted) {
+          setState(prev => ({
+            text: prev.text.slice(0, prev.cursor) + pasted + prev.text.slice(prev.cursor),
+            cursor: prev.cursor + pasted.length,
+          }));
+        }
         return;
       }
 


### PR DESCRIPTION
Refs aws/agentcore-cli#207

## Issues
- **#207** — On Windows terminals that don't bind Ctrl+V to paste (classic conhost / CMD / PowerShell console host), pressing Ctrl+V in an AgentCore CLI input prompt does nothing - the keystroke is silently dropped. Users entering API keys/secrets must fall back to right-click paste (which the reporter confirms works). It is a convenience papercut, not a blocked workflow: every flow is still completable via right-click paste or Windows Terminal's own Ctrl+V (which injects clipboard text the existing code already handles).

## Root cause
Two parts, both verified in actual code at v0.20.2 (git show v0.20.2:...) and HEAD/v1.0.0-preview.16 (files byte-identical, no git history on the file in between). (1) CLI keybinding gap: src/cli/tui/hooks/useTextInput.ts handles Ctrl+W/U/K/A/E (lines 130-186) but has no `key.ctrl && input === 'v'` branch, and the regular-character insert branch (line 210) is gated on `if (input && !key.ctrl && !key.meta)`, so any ctrl-modified key never inserts. No clipboard READ exists anywhere in src (grep found only the clipboard-WRITE in fetch-access and JSON-paste comments); no clipboardy dependency in package.json. (2) Ink 6.8.0 decoding (node_modules/ink): in raw mode a Ctrl+V keystroke arrives as control byte 0x16; parse-keypress.js:446-449 (`s.length===1 && s<='\x1a'`) maps it to name='v', ctrl=true, and use-input.js (`else if (keypress.ctrl) input = keypress.name`) yields input='v', key.ctrl=true. useTextInput therefore receives input='v'/key.ctrl=true and falls through every branch -> swallowed. Environment-dependent: classic conhost passes the raw 0x16 to the app (dropped); Windows Terminal intercepts Ctrl+V and injects clipboard text, which the existing insert branch already handles - matching why right-click paste works (reporter comment confirms). No bracketed-paste mode (no \x1b[?2004h / '2004') anywhere in src or Ink build, so Ink does not surface paste events separately.

## The fix
Add a `key.ctrl && input === 'v'` branch in the useTextInput useInput callback (e.g. after the Ctrl+K handler ~line 148) that synchronously reads the OS clipboard per-platform and inserts the text at the cursor using the same insertion logic as lines 217-220. Mirror the existing cross-platform clipboard-WRITE precedent at src/cli/tui/screens/fetch-access/useFetchAccessFlow.ts:179-185 but for read: Windows -> spawnSync('powershell', ['-NoProfile','-Command','Get-Clipboard']); macOS -> 'pbpaste'; Linux -> 'xclip -o -selection clipboard' (fallback 'xsel -b'). Reuse isWindows/isMacOS from src/lib/utils/platform.ts (confirmed exported). Prefer spawnSync (no new dependency, matches existing approach) over a clipboardy dep. SecretInput masking already covers AC#3: getDisplayValue() in SecretInput.tsx masks the full value once cursor is at end, so inserted pasted text is masked. Note the reported case (classic conhost) is precisely the case the fix addresses; Windows Terminal already worked. Apply normal control-char filtering (strip \r/\x7f/\x08) on the pasted text as the insert branch already does.

_Files touched:_ src/cli/tui/hooks/useTextInput.ts (add a `key.ctrl && input === 'v'` branch in the useInput callback, ~after line 148); reuse isWindows/isMacOS from src/lib/utils/platform.ts; model spawn on src/cli/tui/screens/fetch-access/useFetchAccessFlow.ts:174-185. Fix covers all consumers of the hook: SecretInput.tsx (API key / JWT / payment-connector secret fields) and TextInput.tsx, both of which delegate to useTextInput.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (reverted useTextInput.ts to pre-fix state, kept new tests): the two paste tests FAIL because Ctrl+V is swallowed — `expected 'val:[ab] cur:1' to contain 'val:[apasted-secret-123b]'` (LEFT then Ctrl+V with clipboard 'pasted-secret-123' inserted nothing; value/cursor unchanged) and `expected 'val:[] cur:0' to contain 'val:[abc]'` (Ctrl+V on empty input with clipboard 'a\rb\x7fc' inserted nothing). This exactly matches the documented symptom (keystroke silently dropped, no clipboard text inserted). AFTER (fix restored, byte-identical to branch): all 40 tests in useTextInput.test.tsx pass, deterministically 3/3 reruns. Ctrl+V now reads the OS clipboard via spawnSync (powershell Get-Clipboard / pbpaste / xclip->xsel), strips \r\x7f\x08, splices at cursor and advances cursor by pasted length: 'ab' + LEFT + Ctrl+V -> 'val:[apasted-secret-123b]' cur:18; 'a\rb\x7fc' -> 'val:[abc]'; clipboard-read-failure -> safe no-op 'val:[keep]' cur:4 (no swallowed keystroke). Existing Ctrl+W/U/K/A/E and arrow/backspace tests unchanged. Build clean: OK .../dist/cli/index.mjs.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
