### PR TITLE
fix(status): Set a non-zero exit code on both validation branches. Mer... (#984)

### DIFF
--- a/integ-tests/status.test.ts
+++ b/integ-tests/status.test.ts
@@ -69,7 +69,7 @@ describe('status command', () => {
 
   it('emits failure telemetry for invalid --type', async () => {
     const result = await runCLI(['status', '--type', 'bogus'], projectDir, { env: telemetry.env });
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
     telemetry.assertMetricEmitted({
       command: 'status',
       exit_reason: 'failure',
@@ -80,7 +80,7 @@ describe('status command', () => {
 
   it('emits failure telemetry for invalid --state', async () => {
     const result = await runCLI(['status', '--state', 'bogus'], projectDir, { env: telemetry.env });
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode).toBe(1);
     telemetry.assertMetricEmitted({
       command: 'status',
       exit_reason: 'failure',

--- a/src/cli/commands/status/__tests__/command.test.ts
+++ b/src/cli/commands/status/__tests__/command.test.ts
@@ -1,5 +1,5 @@
-import { registerStatus } from '../command.js';
 import { handleProjectStatus, loadStatusConfig } from '../action.js';
+import { registerStatus } from '../command.js';
 import { Command } from '@commander-js/extra-typings';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/src/cli/commands/status/__tests__/command.test.ts
+++ b/src/cli/commands/status/__tests__/command.test.ts
@@ -1,0 +1,77 @@
+import { registerStatus } from '../command.js';
+import { handleProjectStatus, loadStatusConfig } from '../action.js';
+import { Command } from '@commander-js/extra-typings';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockRender } = vi.hoisted(() => ({
+  mockRender: vi.fn(),
+}));
+
+vi.mock('../../../tui/guards', () => ({
+  requireProject: vi.fn(),
+}));
+
+vi.mock('../../../telemetry/cli-command-run.js', () => ({
+  withCommandRunTelemetry: vi.fn((_command, _attrs, run) => run()),
+}));
+
+vi.mock('../../../operations/dataset', () => ({
+  getDatasetStatus: vi.fn(),
+}));
+
+vi.mock('../action.js', () => ({
+  handleProjectStatus: vi.fn(),
+  handleRuntimeLookup: vi.fn(),
+  loadStatusConfig: vi.fn(),
+}));
+
+vi.mock('../../../feature-flags', () => ({
+  isPreviewEnabled: () => false,
+}));
+
+vi.mock('ink', () => ({
+  Box: ({ children }: { children?: unknown }) => children,
+  Text: ({ children }: { children?: unknown }) => children,
+  render: mockRender,
+}));
+
+describe('status command validation', () => {
+  let program: Command;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    program = new Command();
+    program.exitOverride();
+    registerStatus(program);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.clearAllMocks();
+  });
+
+  it('sets a non-zero exit code for invalid resource type', async () => {
+    await program.parseAsync(['status', '--type', 'bogus'], { from: 'user' });
+
+    expect(process.exitCode).toBe(1);
+    expect(mockRender).toHaveBeenCalled();
+  });
+
+  it('sets a non-zero exit code for invalid state', async () => {
+    await program.parseAsync(['status', '--state', 'bogus'], { from: 'user' });
+
+    expect(process.exitCode).toBe(1);
+    expect(mockRender).toHaveBeenCalled();
+  });
+
+  it('leaves exit code unset for a valid filter', async () => {
+    vi.mocked(loadStatusConfig).mockResolvedValue({} as never);
+    vi.mocked(handleProjectStatus).mockResolvedValue({ success: true, resources: [] } as never);
+
+    await program.parseAsync(['status', '--type', 'agent'], { from: 'user' });
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/src/cli/commands/status/command.tsx
+++ b/src/cli/commands/status/command.tsx
@@ -96,6 +96,7 @@ export const registerStatus = (program: Command) => {
           error: new ValidationError(msg),
         }));
         render(<Text color="red">{msg}</Text>);
+        process.exitCode = 1;
         return;
       }
 
@@ -107,6 +108,7 @@ export const registerStatus = (program: Command) => {
           error: new ValidationError(msg),
         }));
         render(<Text color="red">{msg}</Text>);
+        process.exitCode = 1;
         return;
       }
 


### PR DESCRIPTION
Refs aws/agentcore-cli#984

## Issues
- **#984** — status with an invalid --type/--state prints an error but returns exit code 0, so scripts and CI cannot detect the rejected filter.

## Root cause
In src/cli/commands/status/command.tsx the two argument-validation branches (--type lines 93-101, --state lines 104-112) render an error then bare-return without setting a non-zero exit code; withCommandRunTelemetry (cli-command-run.ts:94-136) only records telemetry and never exits, so parseAsync (cli.ts:174) resolves and Node exits 0. The real error paths at command.tsx:131/:165/:416 all call process.exit(1).

## The fix
Set a non-zero exit code on both validation branches. Merge PR #1603 (process.exitCode = 1 before return, adds command.test.ts) — cleaner than a hard process.exit(1) because it lets cli.ts's finally cleanup run. Close PR #1169 (duplicate, uses process.exit(1), diff is stale against pre-#1317 file and will conflict).

_Files touched:_ src/cli/commands/status/command.tsx — invalid `--type` branch (set exit signal after the render at line 99, before the return at line 100) and invalid `--state` branch (after the render at line 110, before the return at line 111). Test: src/cli/commands/status/__tests__/command.test.ts (new, per PR #1603).

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> Reproduced via built CLI (dist/cli/index.mjs by absolute path) against a minimal scratch project (agentcore/agentcore.json so requireProject passes). BEFORE (fix stashed + rebuilt): `agentcore status --type bogus` printed red "Invalid resource type 'bogus'. Valid types: ..." but exited 0; `--state bogus` printed "Invalid state 'bogus'. Valid states: ..." and exited 0 — the CI/set -e symptom. AFTER (fix restored + rebuilt): both invalid filters print the SAME validation error AND exit 1. Confirmed `bash -c 'set -e; node CLI status --type bogus; echo SHOULD-NOT-PRINT'` aborts (SHOULD-NOT-PRINT not emitted; script exit 1). New test command.test.ts asserts process.exitCode===1 for invalid --type and invalid --state (mockRender called) and process.exitCode undefined for valid --type agent; all 3 pass. Status directory 63/63 green.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
