### PR TITLE
fix(eval): In registerEval add `evalCmd.argument('[subcommand]').act... (#603)

### DIFF
--- a/src/cli/commands/eval/command.tsx
+++ b/src/cli/commands/eval/command.tsx
@@ -3,13 +3,38 @@ import { COMMAND_DESCRIPTIONS } from '../../constants';
 import { getErrorMessage } from '../../errors';
 import { handleListEvalRuns } from '../../operations/eval';
 import { getResultsPath } from '../../operations/eval/storage';
-import { requireProject } from '../../tui/guards';
+import { renderTUI } from '../../tui';
+import { requireProject, requireTTY } from '../../tui/guards';
 import type { Command } from '@commander-js/extra-typings';
 import { Text, render } from 'ink';
 import React from 'react';
 
 export const registerEval = (program: Command) => {
-  const evalCmd = program.command('evals').description(COMMAND_DESCRIPTIONS.evals);
+  const evalCmd = program
+    .command('evals')
+    .description(COMMAND_DESCRIPTIONS.evals)
+    .showHelpAfterError()
+    .showSuggestionAfterError();
+
+  // Catch-all for TUI fallback when no subcommand is specified.
+  // Commander matches named subcommands (e.g. history) first, so this is safe.
+  evalCmd.argument('[subcommand]').action(async (subcommand: string | undefined, _options, cmd) => {
+    if (subcommand) {
+      console.error(`error: '${subcommand}' is not a valid subcommand.`);
+      cmd.outputHelp();
+      process.exit(1);
+    }
+
+    requireProject();
+    requireTTY();
+
+    await renderTUI({
+      initialRoute: { name: 'evals' },
+      enterAltScreen: false,
+      actionOnBack: 'exit',
+      isInteractive: false,
+    });
+  });
 
   evalCmd
     .command('history')


### PR DESCRIPTION
Refs aws/agentcore-cli#603

## Issues
- **#603** — Bare `agentcore evals` prints help instead of opening the interactive eval hub, while `agentcore add`/`remove` open their TUI — an inconsistent entry point. Cosmetic only: `evals history` and the hub (via the main TUI menu) both still work; no functional, data, or deploy impact.

## Root cause
Top-level commands open the TUI only when they register a parent `.action()` calling `renderTUI()`. `add`/`remove` do (add/command.tsx:14-30, remove/command.tsx:161-179); `evals` does not — eval/command.tsx:11-77 registers only `history` and never imports/calls renderTUI, so Commander prints help for bare `agentcore evals`. The eval hub already exists (App.tsx:72 route, :341-356 EvalHubScreen, :172-173 in-TUI dispatch). `traces` is deliberately CLI-only (commands.ts:20, copy.ts:69-76) and `status` renders a static report via render() not renderTUI (status/command.tsx:84-418), so the only real inconsistency is `evals`.

## The fix
In registerEval add `evalCmd.argument('[subcommand]').action(...)` that, on no subcommand, calls requireProject()+requireTTY() then renderTUI({ initialRoute: { name: 'evals' }, enterAltScreen: false, actionOnBack: 'exit', isInteractive: false }); import renderTUI and requireTTY at top of file. Reuses existing 'evals' route/EvalHubScreen — no new screen. Leave traces CLI-only.

_Files touched:_ src/cli/commands/eval/command.tsx (registerEval)

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (fix stashed, rebuilt): bare `agentcore evals` printed the Commander "Usage: agentcore evals [options] [command]" help block (listing only `history` + `help`) and exited 0, regardless of project/TTY — Commander default no-action behavior, never reaching a guard. Original symptom reproduced. AFTER (fixed build at /local/home/aidandal/workplace/issues/bugfix-run/clusters/603/repo/dist/cli/index.mjs): driving bare `agentcore evals` inside a valid project (agentcore/agentcore.json present) on a tui-harness PTY rendered the interactive Eval Hub: header "Evaluations / Choose a view" with options Run On-demand Evaluation, Eval Runs, Run Batch Evaluation, Batch Eval Jobs, Run Insights [preview], Insights Jobs [preview], Online Eval Dashboard, and footer "↑↓ navigate · Enter select · Esc back · Ctrl+C quit" — NOT the Usage help block. Down-arrow moved the `❯` selection cursor from "Run On-demand Evaluation" to "Eval Runs", proving a live interactive TUI. `agentcore evals --help` still prints help; `agentcore evals bogus` errors "error: 'bogus' is not a valid subcommand." + help (exit 1, matching `add`); `agentcore evals history` works unchanged (text + --json {"success":true,"runs":[]}); outside a project / no TTY it fails gracefully via requireProject() ("No agentcore project found.", exit 1) rather than rendering or printing help.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
