### PR TITLE
fix(cli): default new agents to PYTHON_3_13 instead of PYTHON_3_14 (#907)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ Main project configuration using a **flat resource model**. Agents, memories, an
       "build": "CodeZip",
       "entrypoint": "main.py",
       "codeLocation": "app/MyAgent/",
-      "runtimeVersion": "PYTHON_3_14",
+      "runtimeVersion": "PYTHON_3_13",
       "networkMode": "PUBLIC",
       "protocol": "HTTP"
     }
@@ -168,7 +168,7 @@ on the next deployment.
   "build": "CodeZip",
   "entrypoint": "main.py",
   "codeLocation": "app/MyAgent/",
-  "runtimeVersion": "PYTHON_3_14",
+  "runtimeVersion": "PYTHON_3_13",
   "networkMode": "PUBLIC",
   "envVars": [{ "name": "MY_VAR", "value": "my-value" }],
   "instrumentation": {

--- a/docs/container-builds.md
+++ b/docs/container-builds.md
@@ -81,7 +81,7 @@ In `agentcore.json`, set `"build": "Container"`:
   "build": "Container",
   "entrypoint": "main.py",
   "codeLocation": "app/MyAgent/",
-  "runtimeVersion": "PYTHON_3_14"
+  "runtimeVersion": "PYTHON_3_13"
 }
 ```
 

--- a/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
+++ b/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
@@ -87,7 +87,7 @@ describe('mapGenerateConfigToAgent', () => {
     expect(result.name).toBe('TestProject');
     expect(result.build).toBe('CodeZip');
     expect(result.entrypoint).toBe('main.py');
-    expect(result.runtimeVersion).toBe('PYTHON_3_14');
+    expect(result.runtimeVersion).toBe('PYTHON_3_13');
     expect(result.networkMode).toBe('PUBLIC');
     expect(result.protocol).toBe('HTTP');
   });

--- a/src/cli/tui/screens/mcp/__tests__/types.test.ts
+++ b/src/cli/tui/screens/mcp/__tests__/types.test.ts
@@ -1,4 +1,10 @@
-import { AUTHORIZER_TYPE_OPTIONS, ENTER_KB_ID_MANUALLY, SKIP_FOR_NOW, TARGET_TYPE_OPTIONS } from '../types.js';
+import {
+  AUTHORIZER_TYPE_OPTIONS,
+  ENTER_KB_ID_MANUALLY,
+  PYTHON_VERSION_OPTIONS,
+  SKIP_FOR_NOW,
+  TARGET_TYPE_OPTIONS,
+} from '../types.js';
 import { describe, expect, it } from 'vitest';
 
 describe('MCP types constants', () => {
@@ -25,5 +31,13 @@ describe('MCP types constants', () => {
     // Sentinel for the "Enter an existing KB ID manually..." picker entry —
     // the screen branches on this exact id when the user picks the manual path.
     expect(ENTER_KB_ID_MANUALLY).toBe('__enter_kb_id__');
+  });
+
+  it('PYTHON_VERSION_OPTIONS defaults to a universally-available runtime, not PYTHON_3_14', () => {
+    // 3.14 is not yet GA in every region, so it must not be the first/highlighted pick.
+    expect(PYTHON_VERSION_OPTIONS[0]?.id).toBe('PYTHON_3_13');
+    expect(PYTHON_VERSION_OPTIONS[0]?.id).not.toBe('PYTHON_3_14');
+    // 3.14 stays selectable for users in supported regions.
+    expect(PYTHON_VERSION_OPTIONS.some(opt => opt.id === 'PYTHON_3_14')).toBe(true);
   });
 });

--- a/src/cli/tui/screens/mcp/types.ts
+++ b/src/cli/tui/screens/mcp/types.ts
@@ -425,8 +425,8 @@ export const POLICY_ENGINE_MODE_OPTIONS = [
 ] as const;
 
 export const PYTHON_VERSION_OPTIONS = [
-  { id: 'PYTHON_3_14', title: 'Python 3.14', description: 'Latest' },
-  { id: 'PYTHON_3_13', title: 'Python 3.13', description: '' },
+  { id: 'PYTHON_3_13', title: 'Python 3.13', description: 'Recommended' },
+  { id: 'PYTHON_3_14', title: 'Python 3.14', description: 'Not yet available in all regions' },
   { id: 'PYTHON_3_12', title: 'Python 3.12', description: '' },
   { id: 'PYTHON_3_11', title: 'Python 3.11', description: '' },
   { id: 'PYTHON_3_10', title: 'Python 3.10', description: '' },

--- a/src/schema/__tests__/constants.test.ts
+++ b/src/schema/__tests__/constants.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PYTHON_VERSION,
   LANGUAGE_FRAMEWORK_MATRIX,
   ModelProviderSchema,
   NetworkModeSchema,
@@ -74,6 +75,11 @@ describe('RuntimeVersionSchemas', () => {
     expect(NodeRuntimeSchema.safeParse('NODE_16').success).toBe(false);
     expect(NodeRuntimeSchema.safeParse('NODE_24').success).toBe(false);
     expect(RuntimeVersionSchema.safeParse('RUBY_3_0').success).toBe(false);
+  });
+
+  it('defaults new agents to a universally-available Python runtime (not PYTHON_3_14)', () => {
+    expect(DEFAULT_PYTHON_VERSION).toBe('PYTHON_3_13');
+    expect(PythonRuntimeSchema.safeParse(DEFAULT_PYTHON_VERSION).success).toBe(true);
   });
 });
 

--- a/src/schema/constants.ts
+++ b/src/schema/constants.ts
@@ -150,7 +150,7 @@ export const PythonRuntimeSchema = z.enum(['PYTHON_3_10', 'PYTHON_3_11', 'PYTHON
 export type PythonRuntime = z.infer<typeof PythonRuntimeSchema>;
 
 /** Default Python runtime version for new agents and MCP tools */
-export const DEFAULT_PYTHON_VERSION: PythonRuntime = 'PYTHON_3_14';
+export const DEFAULT_PYTHON_VERSION: PythonRuntime = 'PYTHON_3_13';
 
 export const NodeRuntimeSchema = z.enum(['NODE_18', 'NODE_20', 'NODE_22']);
 export type NodeRuntime = z.infer<typeof NodeRuntimeSchema>;


### PR DESCRIPTION
Refs aws/agentcore-cli#907

## Issues
- **#907** — A new user who runs `agentcore init` / `add agent` / `deploy` in any region where PYTHON_3_14 is not yet GA (the reporter used eu-central-1) gets the unsupported runtime written into agentcore.json by default. `agentcore validate` passes, but CloudFormation rejects it via AWS::EarlyValidation::PropertyValidation, leaving the stack stuck in REVIEW_IN_PROGRESS. The CLI then hard-blocks every subsequent deploy with no recovery path, so the user must manually `aws cloudformation delete-stack` to proceed.

## Root cause
verified: DEFAULT_PYTHON_VERSION='PYTHON_3_14' at constants.ts:153 (git blame PR #837/b139c0507), consumed at schema-mapper.ts:129 + packaging fallbacks; picker 'Latest' at mcp/types.ts:428; no region guard in CLI/validate; REVIEW_IN_PROGRESS blocks at stack-status.ts:16 / preflight.ts:288. CDK passthrough at AgentCoreRuntime.ts:243 (no validation). Could not personally confirm service-side regional availability of PYTHON_3_14 (a service fact, not in code).

## The fix
Primary (resolves the reported scenario): lower the default to a universally-available runtime — set DEFAULT_PYTHON_VERSION = 'PYTHON_3_13' in src/schema/constants.ts:153, and stop listing PYTHON_3_14 first/'Latest' in the picker at src/cli/tui/screens/mcp/types.ts:428 (keep it selectable in PythonRuntimeSchema:149 for opt-in in supported regions). This is exactly what the OPEN canonical fix PR #1172 does. For the MCP/Lambda compute path, apply the matching change to the CDK construct's DEFAULT_MCP_PYTHON_VERSION (mcp-utils.ts:5, currently 'PYTHON_3_14') and the lambda.Runtime fallback in McpLambdaCompute.ts:81, then ship a CDK release the vended caret range picks up. Optional hardening (CLOSED PR #1157's approach): special-case REVIEW_IN_PROGRESS in stack-status.ts to detect a never-deployed stuck stack and offer delete-and-retry (a --recover flag), plus surface the CFN early-validation error with a concrete hint. Design decision: prefer a safer default plus clearer error surfacing over a brittle, service-driven region-vs-runtime compatibility table.

_Files touched:_ CLI (primary): src/schema/constants.ts:153 (DEFAULT_PYTHON_VERSION), src/cli/tui/screens/mcp/types.ts:428 (PYTHON_VERSION_OPTIONS ordering/'Latest'); optional src/cli/cloudformation/stack-status.ts:16,68-74 and src/cli/operations/deploy/preflight.ts:288 (REVIEW_IN_PROGRESS recovery). CDK construct @aws/agentcore-cdk (for MCP path only): src/cdk/constructs/components/mcp/mcp-utils.ts:5 (DEFAULT_MCP_PYTHON_VERSION) and McpLambdaCompute.ts:81 fallback. Note: schema-mapper.ts:129 and lib/packaging/{python,index}.ts consume the constant and need no change once the default is fixed.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (HEAD): src/schema/constants.ts:153 DEFAULT_PYTHON_VERSION='PYTHON_3_14'; TUI PYTHON_VERSION_OPTIONS[0] = {id:'PYTHON_3_14', title:'Python 3.14', description:'Latest'}. schema-mapper.ts:128 sets a Python agent's runtimeVersion to DEFAULT_PYTHON_VERSION, so a new agent wrote PYTHON_3_14 into agentcore.json by default. AFTER (fix, built & run): built lib reports DEFAULT_PYTHON_VERSION=PYTHON_3_13 and DEFAULT_RUNTIME_BY_LANGUAGE.Python=PYTHON_3_13. Ran built CLI dist/cli/index.mjs: `create --project-name acfix907 --defaults` then `add agent --name acfix907rt --language Python --framework Strands --model-provider Bedrock --memory none` -> agentcore.json wrote "runtimeVersion": "PYTHON_3_13" (symptom gone). TUI PYTHON_VERSION_OPTIONS[0].id now 'PYTHON_3_13' ("Recommended"); PYTHON_3_14 moved to 2nd, labeled "Not yet available in all regions", still present/selectable. No regression: PythonRuntimeSchema.safeParse('PYTHON_3_14').success===true. Targeted tests (constants/types/schema-mapper) 103 passed incl. 3 new assertions; full `npm run test:unit` = 377 files / 5453 tests passed, 0 failed.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
