### PR TITLE
fix(unit-only): include harness Dockerfile content in deploy hash (#1380)

### DIFF
--- a/src/cli/operations/deploy/__tests__/change-detection.test.ts
+++ b/src/cli/operations/deploy/__tests__/change-detection.test.ts
@@ -1,11 +1,14 @@
 import { canSkipDeploy, computeProjectDeployHash } from '../change-detection';
 import { describe, expect, it, vi } from 'vitest';
 
+let harnessJsonContent = '{"name":"h1","model":{"provider":"bedrock","modelId":"anthropic.claude-3"}}';
+let dockerfileContent = 'FROM python:3.12';
+
 vi.mock('node:fs/promises', () => ({
   readFile: vi.fn().mockImplementation((path: string) => {
-    if (path.includes('harness.json'))
-      return Promise.resolve('{"name":"h1","model":{"provider":"bedrock","modelId":"anthropic.claude-3"}}');
+    if (path.includes('harness.json')) return Promise.resolve(harnessJsonContent);
     if (path.includes('system-prompt.md')) return Promise.resolve('You are a helpful assistant.');
+    if (path.includes('Dockerfile')) return Promise.resolve(dockerfileContent);
     return Promise.reject(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }));
   }),
 }));
@@ -51,6 +54,21 @@ describe('computeProjectDeployHash', () => {
     const hash1 = await computeProjectDeployHash(io1);
     const hash2 = await computeProjectDeployHash(io2);
     expect(hash1).not.toBe(hash2);
+  });
+
+  it('returns different hash when only the referenced Dockerfile content changes', async () => {
+    harnessJsonContent = '{"name":"h1","dockerfile":"Dockerfile"}';
+    try {
+      const io = mockConfigIO({});
+      dockerfileContent = 'FROM python:3.12';
+      const hash1 = await computeProjectDeployHash(io);
+      dockerfileContent = 'FROM python:3.13';
+      const hash2 = await computeProjectDeployHash(io);
+      expect(hash1).not.toBe(hash2);
+    } finally {
+      harnessJsonContent = '{"name":"h1","model":{"provider":"bedrock","modelId":"anthropic.claude-3"}}';
+      dockerfileContent = 'FROM python:3.12';
+    }
   });
 });
 

--- a/src/cli/operations/deploy/change-detection.ts
+++ b/src/cli/operations/deploy/change-detection.ts
@@ -23,9 +23,11 @@ export async function computeProjectDeployHash(configIO: ConfigIO): Promise<stri
 
   for (const harness of projectSpec.harnesses ?? []) {
     const harnessDir = join(projectRoot, harness.path);
+    let dockerfile: string | undefined;
     try {
       const harnessJson = await readFile(join(harnessDir, 'harness.json'), 'utf-8');
       hash.update(harnessJson);
+      dockerfile = JSON.parse(harnessJson)?.dockerfile;
     } catch {
       // harness.json missing — hash will differ from last deploy
     }
@@ -34,6 +36,14 @@ export async function computeProjectDeployHash(configIO: ConfigIO): Promise<stri
       hash.update(prompt);
     } catch {
       // no system prompt
+    }
+    if (dockerfile) {
+      try {
+        const dockerfileContent = await readFile(join(harnessDir, dockerfile), 'utf-8');
+        hash.update(dockerfileContent);
+      } catch {
+        // referenced Dockerfile missing — hash will differ from last deploy
+      }
     }
   }
 


### PR DESCRIPTION
Refs aws/agentcore-cli#1380

## Issues
- **#1380** — For a preview-gated, harness-only project whose harness references a custom Dockerfile, editing only the Dockerfile's contents (not its name) does not change the project deploy hash, so agentcore deploy/agentcore dev reports "No changes detected — skipping deploy" and the cloud AWS::BedrockAgentCore::Harness keeps running the previously-built container image. The user must touch harness.json (or any other hashed input) to force a redeploy.

## Root cause
computeProjectDeployHash (change-detection.ts:14-43) hashes harness.json (line 26) + system-prompt.md (line 32) + aws-targets.json + projectSpec, but never reads the harness Dockerfile content. harness.json stores only the Dockerfile filename (HarnessPrimitive.ts:256), so a content-only edit leaves the hash unchanged; canSkipDeploy (change-detection.ts:52-75, runtimes-length guard at line 56) returns true and short-circuits handleDeploy at useDevDeploy.ts:76-80 and progress.ts:56-62. Note: the brief's cited CDK construct AgentCoreHarnessEnvironment.ts does NOT exist in CDK alpha.19 — harness synth (which passes hasDockerfile/dockerfile/codeLocation to drive the container build) is in the CLI's vended src/assets/cdk/lib/cdk-stack.ts + bin/cdk.ts:102-104 via @aws/agentcore-cdk HarnessDeploymentConfig. Owner is still CLI.

## The fix
In computeProjectDeployHash, after hashing each harness.json, parse it and when harnessSpec.dockerfile is set, readFile the Dockerfile from the harness dir (join(harnessDir, harnessSpec.dockerfile)) and hash.update its content inside a try/catch so a missing file degrades gracefully. Extend change-detection.test.ts (whose readFile mock currently returns only harness.json/system-prompt.md) to mock a Dockerfile and assert a content-only Dockerfile change produces a different hash. This is exactly what open PR #1587 ('fix: include harness Dockerfiles in deploy hash', +13 in change-detection.ts, +36/-4 in change-detection.test.ts) implements; it just needs to land.

_Files touched:_ /local/home/aidandal/workplace/issues/agentcore-cli/src/cli/operations/deploy/change-detection.ts (computeProjectDeployHash, harness loop lines 23-37) plus /local/home/aidandal/workplace/issues/agentcore-cli/src/cli/operations/deploy/__tests__/change-detection.test.ts. Tracked by open PR #1587 (branch fix/harness-dockerfile-deploy-hash).

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (pre-fix code from HEAD, no dockerfile refs): the new unit test 'returns different hash when only the referenced Dockerfile content changes' FAILS — computeProjectDeployHash returns the IDENTICAL hash 6f2f6e5023805fe7 for harness.json {"name":"h1","dockerfile":"Dockerfile"} when only the Dockerfile body changes from 'FROM python:3.12' to 'FROM python:3.13'. AssertionError: expected '6f2f6e5023805fe7' not to be '6f2f6e5023805fe7'. This is the root cause of the reported symptom: a content-only Dockerfile edit leaves the deploy hash unchanged, so canSkipDeploy returns true and the CLI prints 'No changes detected — skipping deploy', leaving the old container running. AFTER (fix/1380 working tree, change-detection.ts reads dockerfile = JSON.parse(harnessJson)?.dockerfile and hashes readFile(join(harnessDir, dockerfile)) under try/catch inside the harness loop): the same test PASSES — hash1 !== hash2. The no-dockerfile-field cases ('returns same hash for same inputs', '16-char hex') still produce stable hashes (graceful degradation via the if(dockerfile) guard + try/catch). Targeted file change-detection.test.ts: 10/10 pass with fix vs 1 fail (9 pass) on pre-fix code, isolating the symptom to exactly the Dockerfile-content scenario.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
