### PR TITLE
fix(deploy): actionable error when no target configured or no AWS creds (#604)

### DIFF
--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -36,6 +36,7 @@ import {
   hasIdentityApiProviders,
   hasIdentityOAuthProviders,
   hasManagedMemoryHarness,
+  NO_DEPLOYMENT_TARGET_GUIDANCE,
   performStackTeardown,
   setupApiKeyProviders,
   setupOAuth2Providers,
@@ -188,10 +189,16 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     const target = targets.find(t => t.name === options.target);
     if (!target) {
       endStep('error', `Target "${options.target}" not found`);
+      // A fresh project ships an empty aws-targets.json and only auto-populates a
+      // default when AWS credentials are detectable. With no credentials configured
+      // the file stays empty, so surface the actionable "no AWS credentials" guidance
+      // here instead of the cryptic "target not found". Throws when creds are absent
+      // (caught by the outer handler); a no-op when valid creds exist.
+      await validateAwsCredentials();
       logger.finalize(false);
       return {
         success: false,
-        error: new ResourceNotFoundError(`Target "${options.target}" not found in aws-targets.json`),
+        error: new ResourceNotFoundError(NO_DEPLOYMENT_TARGET_GUIDANCE),
         logPath: logger.getRelativeLogPath(),
       };
     }

--- a/src/cli/commands/export/harness-action.ts
+++ b/src/cli/commands/export/harness-action.ts
@@ -3,6 +3,7 @@ import { ExportHarnessError, ValidationError } from '../../../lib/errors/types';
 import { AgentNameSchema } from '../../../schema';
 import type { AgentEnvSpec, BuildType, Credential } from '../../../schema';
 import { getErrorMessage } from '../../errors';
+import { NO_DEPLOYMENT_TARGET_GUIDANCE } from '../../operations/deploy';
 import type { AttributeRecorder } from '../../telemetry/cli-command-run.js';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
 import type { CommandAttrs } from '../../telemetry/schemas/command-run.js';
@@ -175,12 +176,7 @@ export async function handleExportHarness(
       if (targets.length === 0) {
         context.exportNotes.push({
           category: 'No AWS deployment target configured',
-          message:
-            'aws-targets.json is empty — running `agentcore deploy` will fail with "Target \\"default\\" not found". ' +
-            'Add a deployment target first:\n\n' +
-            '  agentcore deploy  (interactive mode will prompt for account/region)\n\n' +
-            'Or edit agentcore/aws-targets.json manually:\n\n' +
-            '  [{ "name": "default", "account": "<account-id>", "region": "<region>" }]',
+          message: NO_DEPLOYMENT_TARGET_GUIDANCE,
         });
       }
 

--- a/src/cli/operations/deploy/__tests__/ensure-target.test.ts
+++ b/src/cli/operations/deploy/__tests__/ensure-target.test.ts
@@ -1,5 +1,5 @@
 import { type ConfigIO, ConfigNotFoundError } from '../../../../lib';
-import { ensureDefaultDeploymentTarget } from '../ensure-target.js';
+import { NO_DEPLOYMENT_TARGET_GUIDANCE, ensureDefaultDeploymentTarget } from '../ensure-target.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockDetectAwsContext } = vi.hoisted(() => ({
@@ -87,5 +87,13 @@ describe('ensureDefaultDeploymentTarget', () => {
     await ensureDefaultDeploymentTarget(configIO);
 
     expect(writes[0]).toEqual([{ name: 'default', account: '123456789012', region: 'eu-west-1' }]);
+  });
+});
+
+describe('NO_DEPLOYMENT_TARGET_GUIDANCE', () => {
+  it('replaces the cryptic "target not found" string with both documented remediations', () => {
+    expect(NO_DEPLOYMENT_TARGET_GUIDANCE).not.toContain('not found in aws-targets.json');
+    expect(NO_DEPLOYMENT_TARGET_GUIDANCE).toContain('agentcore deploy');
+    expect(NO_DEPLOYMENT_TARGET_GUIDANCE).toContain('aws-targets.json');
   });
 });

--- a/src/cli/operations/deploy/ensure-target.ts
+++ b/src/cli/operations/deploy/ensure-target.ts
@@ -2,6 +2,19 @@ import { type ConfigIO, ConfigNotFoundError } from '../../../lib';
 import { detectAwsContext } from '../../aws';
 
 /**
+ * Actionable guidance shown when no deployment target is configured (valid AWS
+ * credentials are present, but `aws-targets.json` has no matching target).
+ * Shared by the deploy command and the export flow so the remediation steps
+ * don't diverge.
+ */
+export const NO_DEPLOYMENT_TARGET_GUIDANCE =
+  'No deployment target is configured in agentcore/aws-targets.json.\n\n' +
+  'To fix this:\n' +
+  '  1. Run `agentcore deploy` (interactive mode will prompt for account/region)\n' +
+  '  2. Or add a target to agentcore/aws-targets.json:\n' +
+  '     [{ "name": "default", "account": "<account-id>", "region": "<region>" }]';
+
+/**
  * Ensure `aws-targets.json` has at least one deployment target.
  *
  * Freshly-created projects (via `agentcore create`, interactive or not) write an

--- a/src/cli/operations/deploy/index.ts
+++ b/src/cli/operations/deploy/index.ts
@@ -63,7 +63,7 @@ export {
   type OnlineEvalEnableResult,
 } from './post-deploy-online-evals';
 
-export { ensureDefaultDeploymentTarget } from './ensure-target';
+export { ensureDefaultDeploymentTarget, NO_DEPLOYMENT_TARGET_GUIDANCE } from './ensure-target';
 
 // Managed-memory heads-up (shared by the CLI command + TUI deploy flow + add harness)
 export {


### PR DESCRIPTION
Refs aws/agentcore-cli#604

## Issues
- **#604** — On a freshly-created project, `agentcore deploy --dry-run` (the issue calls it `--plan`) with no AWS credentials configured fails with a developer-facing message — `Target "default" not found in aws-targets.json` — instead of telling the user that no deployment target is configured, that the likely cause is missing AWS credentials, and how to fix it. At filing time (Mar 2026) this hit every fresh project; at v0.20.2 it only hits the no-credentials edge case because deploy now auto-creates a default target when creds are detectable. Pure UX/error-message quality issue; functionality is intact.

## Root cause
A fresh project writes an empty aws-targets.json (src/cli/commands/create/action.ts:96 writes []). handleDeploy calls ensureDefaultDeploymentTarget (src/cli/operations/deploy/actions.ts:156), which only auto-populates a 'default' target if detectAwsContext()/detectAccount() returns an accountId (ensure-target.ts:40-46). When no credentials are configured, detectAccount returns null (src/cli/aws/account.ts:58), so no target is written and the code falls through to the bare ResourceNotFoundError('Target \"default\" not found in aws-targets.json') at actions.ts:164. That ResourceNotFoundError is surfaced verbatim to the terminal (command.tsx:60 console.error(deployResult.error.message)). There is no credential validation gate before this point on a normal/plan deploy — validateAwsCredentials() runs only for teardown deploys (actions.ts:222). Note: expired/invalid creds are NOT affected — detectAccount throws AwsCredentialsError (account.ts:35-49) which propagates through the un-try/caught detectAwsContext call to handleDeploy's outer catch (actions.ts:923) and yields the good 'AWS credentials expired' message.

## The fix
In handleDeploy, before the empty-target lookup, distinguish the no-credentials case from a genuinely-missing target. Simplest correct approach: have ensureDefaultDeploymentTarget (or handleDeploy) call validateAwsCredentials() when no targets exist and none could be auto-populated, so the no-creds case yields the existing actionable AwsCredentialsError message (account.ts:66-77 via getAwsLoginGuidance). Then reword the residual 'Target not found' ResourceNotFoundError (actions.ts:164) into an actionable message that says no deployment target is configured and lists the two remediations already documented in export/harness-action.ts:179-183: run `agentcore deploy` interactively to be prompted, or add a target to agentcore/aws-targets.json. Extract that guidance string into a shared constant so the deploy and export paths don't diverge. Small, self-contained in the CLI. Correction vs brief: do not claim the expired-creds case still shows the cryptic error — it is already handled.

_Files touched:_ src/cli/commands/deploy/actions.ts:156-167 (ensureDefaultDeploymentTarget call + target-not-found return); add a no-creds guard reusing validateAwsCredentials/getAwsLoginGuidance from src/cli/aws/account.ts:66-77; reword using guidance text from src/cli/commands/export/harness-action.ts:179-183 (extract to a shared constant). Optionally surface the credentials guard inside src/cli/operations/deploy/ensure-target.ts.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> Drove the real handleDeploy against a freshly-created project (real `agentcore create --no-agent`) with the AWS layer mocked at the single detectAccount seam (zero real AWS calls), comparing shipped HEAD vs fix/604.

BEFORE (shipped source): no-creds + empty aws-targets.json -> handleDeploy returns ResourceNotFoundError with message exactly `Target "default" not found in aws-targets.json` (the cryptic developer string from the symptom). Valid-creds + absent --target -> `Target "does-not-exist" not found in aws-targets.json`. Both assertions RED.

AFTER (fix/604): (1) No-creds case -> AwsCredentialsError, error.message = `No AWS credentials configured.

To fix this:
  1. <getAwsLoginGuidance>
  2. Or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY...`, error.shortMessage = `No AWS credentials configured.`; the literal `not found in aws-targets.json` no longer appears. (2) Missing-target (valid creds) -> ResourceNotFoundError(NO_DEPLOYMENT_TARGET_GUIDANCE) = `No deployment target is configured in agentcore/aws-targets.json` + both documented remediations (run `agentcore deploy` interactively; or add a target to agentcore/aws-targets.json). (3) Regression guard: expired-creds still yields unchanged `AWS credentials expired.` (green before and after).

Mechanism confirmed in src/cli/commands/deploy/actions.ts:190-204 — the `if (!target)` branch now calls `await validateAwsCredentials()` BEFORE returning, which throws AwsCredentialsError (account.ts:66-77) when detectAccount()

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
