### PR TITLE
fix(cli): Add a CLI pre-deploy check that, for each onlineEvalConfi... (#570)

### DIFF
--- a/src/cli/operations/deploy/__tests__/preflight-evaluators.test.ts
+++ b/src/cli/operations/deploy/__tests__/preflight-evaluators.test.ts
@@ -1,0 +1,53 @@
+import { validateOnlineEvalEvaluators } from '../preflight.js';
+import type { AgentCoreProjectSpec } from '../../../../schema';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetEvaluator = vi.fn();
+
+vi.mock('../../../aws/agentcore-control', () => ({
+  getEvaluator: (...args: unknown[]) => mockGetEvaluator(...args),
+}));
+
+function spec(partial: Partial<AgentCoreProjectSpec>): AgentCoreProjectSpec {
+  return { evaluators: [], onlineEvalConfigs: [], ...partial } as AgentCoreProjectSpec;
+}
+
+describe('validateOnlineEvalEvaluators', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('throws naming the config and missing evaluator when a referenced evaluator is gone', async () => {
+    mockGetEvaluator.mockRejectedValue(new Error('not found'));
+
+    await expect(
+      validateOnlineEvalEvaluators(
+        spec({ onlineEvalConfigs: [{ name: 'cfg', evaluators: ['Builtin.GoalSuccessRate'] }] as any }),
+        'us-east-1'
+      )
+    ).rejects.toThrow(/Builtin\.GoalSuccessRate.*online eval config "cfg".*no longer exists in us-east-1/s);
+  });
+
+  it('does not flag evaluators this deploy is about to create (project-managed, no API call)', async () => {
+    await expect(
+      validateOnlineEvalEvaluators(
+        spec({
+          evaluators: [{ name: 'MyEval' }] as any,
+          onlineEvalConfigs: [{ name: 'cfg', evaluators: ['MyEval'] }] as any,
+        }),
+        'us-east-1'
+      )
+    ).resolves.toBeUndefined();
+    expect(mockGetEvaluator).not.toHaveBeenCalled();
+  });
+
+  it('passes when non-project-managed references resolve', async () => {
+    mockGetEvaluator.mockResolvedValue({ evaluatorId: 'Builtin.GoalSuccessRate' });
+
+    await expect(
+      validateOnlineEvalEvaluators(
+        spec({ onlineEvalConfigs: [{ name: 'cfg', evaluators: ['Builtin.GoalSuccessRate'] }] as any }),
+        'us-east-1'
+      )
+    ).resolves.toBeUndefined();
+    expect(mockGetEvaluator).toHaveBeenCalledWith({ region: 'us-east-1', evaluatorId: 'Builtin.GoalSuccessRate' });
+  });
+});

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -2,6 +2,7 @@ import { ConfigIO, DOCKERFILE_NAME, getDockerfilePath, requireConfigRoot, resolv
 import { ValidationError } from '../../../lib/errors/types';
 import type { AgentCoreProjectSpec, AwsDeploymentTarget } from '../../../schema';
 import { validateAwsCredentials } from '../../aws/account';
+import { getEvaluator } from '../../aws/agentcore-control';
 import { LocalCdkProject } from '../../cdk/local-cdk-project';
 import { CdkToolkitWrapper, createCdkToolkitWrapper, silentIoHost } from '../../cdk/toolkit-lib';
 import { checkBootstrapStatus, checkStacksStatus, formatCdkEnvironment } from '../../cloudformation';
@@ -145,6 +146,16 @@ export async function validateProject(): Promise<PreflightContext> {
     await validateAwsCredentials();
   }
 
+  // Validate that evaluators referenced by online eval configs but NOT managed by this project
+  // (Builtin.* IDs, ARNs, and custom names absent from projectSpec.evaluators) still exist in the
+  // account. Without this, a reference to an evaluator deleted out-of-band passes schema + synth and
+  // only fails at CloudFormation with an opaque resource error. Skipped on teardown (no creation) and
+  // when there are no targets to resolve against (credentials/region unavailable).
+  const evaluatorTarget = awsTargets[0];
+  if (!isTeardownDeploy && evaluatorTarget) {
+    await validateOnlineEvalEvaluators(projectSpec, evaluatorTarget.region);
+  }
+
   return { projectSpec, awsTargets, cdkProject, isTeardownDeploy, isFirstDeploy: !hasExistingStack };
 }
 
@@ -213,6 +224,41 @@ export async function validateHarnessSpecs(projectSpec: AgentCoreProjectSpec, co
   }
   if (errors.length > 0) {
     throw new ValidationError(`Invalid harness configuration:\n${errors.join('\n')}`);
+  }
+}
+
+/**
+ * Verify that every evaluator referenced by an online eval config which this project does NOT manage
+ * still exists in the account. Project-managed custom evaluators (those in projectSpec.evaluators)
+ * are skipped — this same deploy is about to create them, so checking would be a false positive.
+ * Builtin.* IDs, ARNs, and custom names absent from the project are resolved via getEvaluator; a
+ * missing one throws an actionable ValidationError naming the config and the offending evaluator,
+ * which gates before CDK synth instead of surfacing as an opaque CloudFormation rollback.
+ */
+export async function validateOnlineEvalEvaluators(projectSpec: AgentCoreProjectSpec, region: string): Promise<void> {
+  const configs = projectSpec.onlineEvalConfigs ?? [];
+  if (configs.length === 0) return;
+
+  const projectEvaluators = new Set((projectSpec.evaluators ?? []).map(e => e.name));
+  const errors: string[] = [];
+
+  for (const config of configs) {
+    for (const ref of config.evaluators ?? []) {
+      // Skip evaluators this deploy is about to create.
+      if (projectEvaluators.has(ref)) continue;
+      try {
+        await getEvaluator({ region, evaluatorId: ref });
+      } catch {
+        errors.push(
+          `Evaluator "${ref}" referenced by online eval config "${config.name}" no longer exists in ${region}. ` +
+            `Recreate it or remove the reference from agentcore.json, then deploy.`
+        );
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new ValidationError(errors.join('\n'));
   }
 }
 


### PR DESCRIPTION
Refs aws/agentcore-cli#570

## Issues
- **#570** — If an online eval config references an evaluator (by Builtin.* ID, ARN, or a previously-deployed custom evaluator) that has since been deleted out-of-band in the console, the next `agentcore deploy` fails at CloudFormation execution with a raw, unenriched resource error and no actionable guidance. The deploy fails safely (CFN rolls back), but the user is left guessing what went wrong, matching the issue's "some error -> should be better error handling."

## Root cause
No pre-deploy evaluator-existence validation exists anywhere. (1) Schema online-eval-config.ts L37-38: `evaluators` is z.array(z.string().min(1)) accepting custom names, Builtin.* IDs, or ARNs as plain strings, with no existence check. (2) CDK construct AgentCoreOnlineEvaluationConfig.ts evaluatorRefs map (alpha.39 L162-181; identical at the CLI-pinned alpha.19 L134-152 per `src/assets/cdk/package.json` "@aws/agentcore-cdk": "^0.1.0-alpha.19") passes Builtin/ARN refs straight through as evaluatorId and only validates project-local custom evaluators against its construct-local `evaluators` map -- so synth always succeeds and the failure only surfaces at CloudFormation execution when the underlying evaluator is gone. (3) preflight.ts validateProject (L66-147) checks runtime names, Dockerfiles, harness specs, and AWS creds but never evaluator existence; deploy/validate.ts validateDeployOptions (L8-11) is a stub that always returns valid; getEvaluator/listAllEvaluators in agentcore-control.ts are used only by import/status/run-eval, never in deploy preflight. (4) The raw CFN error bubbles through handleDeploy's top-level catch (actions.ts L923-926, toError(err)) and renders as deployResult.error.message (command.tsx L60) in the non-interactive path and via formatError in the TUI hook (useCdkPreflight.ts) -- no evaluator-aware enrichment in either path. (5) The graceful post-deploy enable path (post-deploy-online-evals.ts collects errors as warnings) runs only after runDeploy succeeds (actions.ts L782, after the L494 deploy), so it never reaches the deleted-evaluator case. Correction to brief: formatError is the TUI render path only; the headless command path renders error.message directly -- substance (no enrichment) is unchanged. Behavior identical at alpha.19 and alpha.39, so not silently fixed.

## The fix
Add a CLI pre-deploy check that, for each onlineEvalConfig, resolves every referenced evaluator that is NOT a project-managed resource (Builtin.* IDs, ARNs, and any custom names not in projectSpec.evaluators) against the account via getEvaluator (agentcore-control.ts ~L496) or listAllEvaluators (~L628), and throws an actionable ValidationError naming the config + missing evaluator (e.g. "Evaluator X referenced by online eval config Y no longer exists in <region>. Recreate it or remove the reference from agentcore.json, then deploy."). Wire it into validateProject in preflight.ts so it gates before synth. Optionally map the matching CloudFormation CREATE/UPDATE_FAILED evaluator error in the actions.ts catch to the same message as a race backstop. Design note: skip on teardown deploys (mirrors the existing credential/harness skip) and only network-validate refs that aren't project-managed, to avoid false positives on evaluators this deploy is itself about to create.

_Files touched:_ CLI: src/cli/operations/deploy/preflight.ts (new evaluator-existence check inside validateProject, after validateHarnessSpecs), reusing src/cli/aws/agentcore-control.ts getEvaluator/listAllEvaluators; optional backstop enrichment in src/cli/commands/deploy/actions.ts (~L923 catch). No CDK change required -- the pass-through in agentcore-l3-cdk-constructs src/cdk/constructs/components/primitives/evaluator/AgentCoreOnlineEvaluationConfig.ts is by design.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE: `git show main:src/cli/operations/deploy/preflight.ts` has NO evaluator-existence check (grep for validateOnlineEvalEvaluators/getEvaluator/"no longer exists" => "NOT PRESENT ON MAIN"); a deleted evaluator referenced by an online eval config passes schema + CDK synth and only fails opaquely at CloudFormation.

AFTER (real built CLI dist/cli/index.mjs, AWS_PROFILE=deploy, scratch project acfix570 with a harness so it is a real deploy):
(a) onlineEvalConfigs myMonitor referencing "Builtin.NonExistentEvaluatorXYZ" -> `deploy --dry-run --yes` halts at the "Validate project" preflight step (never reaches synth/CFN) printing exactly: `Evaluator "Builtin.NonExistentEvaluatorXYZ" referenced by online eval config "myMonitor" no longer exists in us-east-1. Recreate it or remove the reference from agentcore.json, then deploy.` Headless `--json` path renders the same string in `{"success":false,...,"error":"..."}`.
(b1) Same config pointing at the genuinely-existing Builtin.Correctness -> `{"success":true,...}` (no false positive).
(b2) Config pointing at project-managed evaluator "MyProjectEval" (present in projectSpec.evaluators, NOT yet in AWS — this deploy creates it) -> `{"success":true,...}`, no API call, no false positive.
(c) Teardown deploy (all gate resources emptied incl. harnesses, deployed-state.json targets={default:{}} so isTeardownDeploy=true, bogus Builtin.NonExistentEvaluatorXYZ still referenced) -> `{"success":true,...}`; deploy log shows "STEP: Validate project".

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
