### PR TITLE
fix(cli): Add `--endpoint <name>` to `agentcore invoke`, thread it ... (#986, #1554)

### DIFF
--- a/src/cli/aws/__tests__/agentcore-invoke-qualifier.test.ts
+++ b/src/cli/aws/__tests__/agentcore-invoke-qualifier.test.ts
@@ -1,0 +1,99 @@
+import { invokeAgentRuntime, invokeAgentRuntimeStreaming } from '../agentcore.js';
+import type { InvokeAgentRuntimeOptions } from '../agentcore.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const commandArgs: Record<string, unknown>[] = [];
+const mockSend = vi.fn();
+
+vi.mock('@aws-sdk/client-bedrock-agentcore', () => {
+  class MockBedrockAgentCoreClient {
+    send = mockSend;
+    middlewareStack = { add: vi.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    constructor(_config: unknown) {}
+  }
+  class MockInvokeAgentRuntimeCommand {
+    input: Record<string, unknown>;
+    constructor(args: Record<string, unknown>) {
+      this.input = args;
+      commandArgs.push(args);
+    }
+  }
+  return {
+    BedrockAgentCoreClient: MockBedrockAgentCoreClient,
+    InvokeAgentRuntimeCommand: MockInvokeAgentRuntimeCommand,
+  };
+});
+
+vi.mock('../account.js', () => ({
+  getCredentialProvider: vi.fn().mockReturnValue(() =>
+    Promise.resolve({ accessKeyId: 'test', secretAccessKey: 'test' })
+  ),
+}));
+
+function makeByteResponse(body: string) {
+  return {
+    runtimeSessionId: 'sess-1',
+    response: {
+      transformToByteArray: () => Promise.resolve(new TextEncoder().encode(body)),
+    },
+  };
+}
+
+function makeStreamResponse(body: string) {
+  return {
+    runtimeSessionId: 'sess-1',
+    response: {
+      transformToWebStream: () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(body));
+            controller.close();
+          },
+        }),
+    },
+  };
+}
+
+const BASE: InvokeAgentRuntimeOptions = {
+  region: 'us-east-1',
+  runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123:runtime/r',
+  payload: 'hi',
+};
+
+describe('SigV4 invoke qualifier', () => {
+  beforeEach(() => {
+    commandArgs.length = 0;
+    mockSend.mockReset();
+  });
+
+  it('sets qualifier on the non-streaming command when endpoint is provided', async () => {
+    mockSend.mockResolvedValue(makeByteResponse('{"result":"ok"}'));
+    await invokeAgentRuntime({ ...BASE, endpoint: 'prod' });
+    expect(commandArgs[0]?.qualifier).toBe('prod');
+  });
+
+  it('omits qualifier on the non-streaming command when no endpoint is provided', async () => {
+    mockSend.mockResolvedValue(makeByteResponse('{"result":"ok"}'));
+    await invokeAgentRuntime({ ...BASE });
+    expect(commandArgs[0]).not.toHaveProperty('qualifier');
+  });
+
+  it('sets qualifier on the streaming command when endpoint is provided', async () => {
+    mockSend.mockResolvedValue(makeStreamResponse('data: "hi"\n'));
+    const { stream } = await invokeAgentRuntimeStreaming({ ...BASE, endpoint: 'staging' });
+    for await (const _ of stream) {
+      // drain
+    }
+    expect(commandArgs[0]?.qualifier).toBe('staging');
+  });
+
+  it('omits qualifier on the streaming command when no endpoint is provided', async () => {
+    mockSend.mockResolvedValue(makeStreamResponse('data: "hi"\n'));
+    const { stream } = await invokeAgentRuntimeStreaming({ ...BASE });
+    for await (const _ of stream) {
+      // drain
+    }
+    expect(commandArgs[0]).not.toHaveProperty('qualifier');
+  });
+});

--- a/src/cli/aws/__tests__/agentcore-invoke-qualifier.test.ts
+++ b/src/cli/aws/__tests__/agentcore-invoke-qualifier.test.ts
@@ -26,9 +26,9 @@ vi.mock('@aws-sdk/client-bedrock-agentcore', () => {
 });
 
 vi.mock('../account.js', () => ({
-  getCredentialProvider: vi.fn().mockReturnValue(() =>
-    Promise.resolve({ accessKeyId: 'test', secretAccessKey: 'test' })
-  ),
+  getCredentialProvider: vi
+    .fn()
+    .mockReturnValue(() => Promise.resolve({ accessKeyId: 'test', secretAccessKey: 'test' })),
 }));
 
 function makeByteResponse(body: string) {

--- a/src/cli/aws/__tests__/agentcore-invoke-qualifier.test.ts
+++ b/src/cli/aws/__tests__/agentcore-invoke-qualifier.test.ts
@@ -1,4 +1,4 @@
-import { invokeAgentRuntime, invokeAgentRuntimeStreaming } from '../agentcore.js';
+import { invokeAgentRuntime, invokeAgentRuntimeStreaming, invokeAguiRuntime } from '../agentcore.js';
 import type { InvokeAgentRuntimeOptions } from '../agentcore.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -94,6 +94,24 @@ describe('SigV4 invoke qualifier', () => {
     for await (const _ of stream) {
       // drain
     }
+    expect(commandArgs[0]).not.toHaveProperty('qualifier');
+  });
+
+  it('sets qualifier on the AGUI command when endpoint is provided', async () => {
+    mockSend.mockResolvedValue(makeStreamResponse('data: {}\n\n'));
+    await invokeAguiRuntime(
+      { region: BASE.region, runtimeArn: BASE.runtimeArn, endpoint: 'prod' },
+      { threadId: 't', runId: 'r', messages: [], tools: [], context: [], state: {}, forwardedProps: {} }
+    );
+    expect(commandArgs[0]?.qualifier).toBe('prod');
+  });
+
+  it('omits qualifier on the AGUI command when no endpoint is provided', async () => {
+    mockSend.mockResolvedValue(makeStreamResponse('data: {}\n\n'));
+    await invokeAguiRuntime(
+      { region: BASE.region, runtimeArn: BASE.runtimeArn },
+      { threadId: 't', runId: 'r', messages: [], tools: [], context: [], state: {}, forwardedProps: {} }
+    );
     expect(commandArgs[0]).not.toHaveProperty('qualifier');
   });
 });

--- a/src/cli/aws/agentcore.ts
+++ b/src/cli/aws/agentcore.ts
@@ -367,6 +367,7 @@ export async function invokeAgentRuntimeStreaming(options: InvokeAgentRuntimeOpt
     runtimeSessionId: options.sessionId,
     runtimeUserId: options.userId ?? DEFAULT_RUNTIME_USER_ID,
     ...(options.baggage && { baggage: options.baggage }),
+    ...(options.endpoint && { qualifier: options.endpoint }),
   });
 
   const response = await client.send(command);
@@ -463,6 +464,7 @@ export async function invokeAgentRuntime(options: InvokeAgentRuntimeOptions): Pr
     runtimeSessionId: options.sessionId,
     runtimeUserId: options.userId ?? DEFAULT_RUNTIME_USER_ID,
     ...(options.baggage && { baggage: options.baggage }),
+    ...(options.endpoint && { qualifier: options.endpoint }),
   });
 
   const response = await client.send(command);

--- a/src/cli/aws/agentcore.ts
+++ b/src/cli/aws/agentcore.ts
@@ -1061,6 +1061,8 @@ export interface AguiInvokeOptions {
   headers?: Record<string, string>;
   /** Bearer token for CUSTOM_JWT auth — not yet supported for AGUI, will throw if provided */
   bearerToken?: string;
+  /** Runtime endpoint qualifier (the endpoint NAME, e.g. prod/staging). Defaults to DEFAULT when omitted. */
+  endpoint?: string;
 }
 
 export interface AguiStreamingInvokeResult {
@@ -1092,6 +1094,7 @@ export async function invokeAguiRuntime(
     accept: 'text/event-stream',
     runtimeSessionId: options.sessionId,
     runtimeUserId: options.userId ?? DEFAULT_RUNTIME_USER_ID,
+    ...(options.endpoint && { qualifier: options.endpoint }),
   });
 
   const response = await client.send(command);

--- a/src/cli/aws/index.ts
+++ b/src/cli/aws/index.ts
@@ -16,7 +16,14 @@ export {
   type AgentRuntimeStatusResult,
   type GetAgentRuntimeStatusOptions,
 } from './agentcore-control';
-export { streamLogs, searchLogs, type LogEvent, type StreamLogsOptions, type SearchLogsOptions } from './cloudwatch';
+export {
+  streamLogs,
+  searchLogs,
+  resolveEndpointName,
+  type LogEvent,
+  type StreamLogsOptions,
+  type SearchLogsOptions,
+} from './cloudwatch';
 export { enableTransactionSearch } from './transaction-search';
 export {
   startPolicyGeneration,

--- a/src/cli/commands/invoke/__tests__/invoke.test.ts
+++ b/src/cli/commands/invoke/__tests__/invoke.test.ts
@@ -280,17 +280,21 @@ describe('invoke command', () => {
   // AGENTCORE_RUNTIME_ENDPOINT env var — forces CLI mode.
   // --------------------------------------------------------------------------
   describe('endpoint mode routing', () => {
-    it('AGENTCORE_RUNTIME_ENDPOINT (no prompt/flag) forces CLI mode instead of silently routing to the TUI', async () => {
+    it('AGENTCORE_RUNTIME_ENDPOINT (no prompt/flag/json) forces CLI mode instead of silently routing to the TUI', async () => {
       // Regression for #986/#1554: previously the env var alone never forced CLI
-      // mode, so the user dropped into the TUI and silently hit DEFAULT. Now the
-      // resolved non-DEFAULT endpoint forces CLI mode -> the action layer reports
-      // "No prompt provided" (NOT the TUI requireTTY guard).
-      const result = await runCLI(['invoke', '--json'], projectDir, {
+      // mode, so the user dropped into the TUI and silently hit DEFAULT. NO --json
+      // and NO other CLI flag here on purpose — the resolved non-DEFAULT endpoint
+      // (`endpoint !== undefined` in the gate) is the ONLY thing forcing CLI mode,
+      // so this exercises the new clause directly. CLI mode reaches the action
+      // layer, which resolves the invoke target and fails with "No deployed
+      // targets found" (this project has an agent but no deployed state). If the
+      // `endpoint !== undefined` clause were removed, this would instead route to
+      // the TUI and hit the requireTTY guard ("requires an interactive terminal").
+      const result = await runCLI(['invoke'], projectDir, {
         env: { ...telemetry.env, AGENTCORE_RUNTIME_ENDPOINT: 'staging' },
       });
       expect(result.exitCode).toBe(1);
-      const json = JSON.parse(result.stdout);
-      expect(json.success).toBe(false);
+      expect(result.stderr).toContain('No deployed targets found');
       expect(result.stderr).not.toContain('requires an interactive terminal');
       telemetry.assertMetricEmitted({ command: 'invoke', endpoint_source: 'env' });
     });

--- a/src/cli/commands/invoke/__tests__/invoke.test.ts
+++ b/src/cli/commands/invoke/__tests__/invoke.test.ts
@@ -270,4 +270,48 @@ describe('invoke command', () => {
       expect(result.stderr).not.toContain('requires an interactive terminal');
     });
   });
+
+  // --------------------------------------------------------------------------
+  // Endpoint mode routing.
+  //
+  // The same no-TTY signature lets us prove the env-var fallback no longer
+  // silently drops into the TUI (which would invoke the DEFAULT endpoint). A
+  // non-DEFAULT resolved endpoint — whether from --endpoint or the
+  // AGENTCORE_RUNTIME_ENDPOINT env var — forces CLI mode.
+  // --------------------------------------------------------------------------
+  describe('endpoint mode routing', () => {
+    it('AGENTCORE_RUNTIME_ENDPOINT (no prompt/flag) forces CLI mode instead of silently routing to the TUI', async () => {
+      // Regression for #986/#1554: previously the env var alone never forced CLI
+      // mode, so the user dropped into the TUI and silently hit DEFAULT. Now the
+      // resolved non-DEFAULT endpoint forces CLI mode -> the action layer reports
+      // "No prompt provided" (NOT the TUI requireTTY guard).
+      const result = await runCLI(['invoke', '--json'], projectDir, {
+        env: { ...telemetry.env, AGENTCORE_RUNTIME_ENDPOINT: 'staging' },
+      });
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(result.stderr).not.toContain('requires an interactive terminal');
+      telemetry.assertMetricEmitted({ command: 'invoke', endpoint_source: 'env' });
+    });
+
+    it('records endpoint_source=flag when --endpoint is passed', async () => {
+      // --endpoint forces CLI mode; the agent has no named endpoint configured so
+      // the action layer rejects it — but the telemetry attr is emitted regardless.
+      const result = await runCLI(['invoke', 'hi', '--endpoint', 'prod', '--json'], projectDir, {
+        env: telemetry.env,
+      });
+      expect(result.exitCode).toBe(1);
+      const json = JSON.parse(result.stdout);
+      expect(json.success).toBe(false);
+      expect(result.stderr).not.toContain('requires an interactive terminal');
+      telemetry.assertMetricEmitted({ command: 'invoke', endpoint_source: 'flag' });
+    });
+
+    it('records endpoint_source=default when neither --endpoint nor the env var is set', async () => {
+      const result = await runCLI(['invoke', 'hi', '--json'], projectDir, { env: telemetry.env });
+      expect(result.exitCode).toBe(1);
+      telemetry.assertMetricEmitted({ command: 'invoke', endpoint_source: 'default' });
+    });
+  });
 });

--- a/src/cli/commands/invoke/__tests__/invoke.test.ts
+++ b/src/cli/commands/invoke/__tests__/invoke.test.ts
@@ -276,7 +276,7 @@ describe('invoke command', () => {
   //
   // The same no-TTY signature lets us prove the env-var fallback no longer
   // silently drops into the TUI (which would invoke the DEFAULT endpoint). A
-  // non-DEFAULT resolved endpoint — whether from --endpoint or the
+  // non-DEFAULT resolved endpoint — whether from --runtime-endpoint or the
   // AGENTCORE_RUNTIME_ENDPOINT env var — forces CLI mode.
   // --------------------------------------------------------------------------
   describe('endpoint mode routing', () => {
@@ -299,10 +299,10 @@ describe('invoke command', () => {
       telemetry.assertMetricEmitted({ command: 'invoke', endpoint_source: 'env' });
     });
 
-    it('records endpoint_source=flag when --endpoint is passed', async () => {
-      // --endpoint forces CLI mode; the agent has no named endpoint configured so
-      // the action layer rejects it — but the telemetry attr is emitted regardless.
-      const result = await runCLI(['invoke', 'hi', '--endpoint', 'prod', '--json'], projectDir, {
+    it('records endpoint_source=flag when --runtime-endpoint is passed', async () => {
+      // --runtime-endpoint forces CLI mode; the agent has no named endpoint configured
+      // so the action layer rejects it — but the telemetry attr is emitted regardless.
+      const result = await runCLI(['invoke', 'hi', '--runtime-endpoint', 'prod', '--json'], projectDir, {
         env: telemetry.env,
       });
       expect(result.exitCode).toBe(1);
@@ -312,7 +312,7 @@ describe('invoke command', () => {
       telemetry.assertMetricEmitted({ command: 'invoke', endpoint_source: 'flag' });
     });
 
-    it('records endpoint_source=default when neither --endpoint nor the env var is set', async () => {
+    it('records endpoint_source=default when neither --runtime-endpoint nor the env var is set', async () => {
       const result = await runCLI(['invoke', 'hi', '--json'], projectDir, { env: telemetry.env });
       expect(result.exitCode).toBe(1);
       telemetry.assertMetricEmitted({ command: 'invoke', endpoint_source: 'default' });

--- a/src/cli/commands/invoke/__tests__/resolve.test.ts
+++ b/src/cli/commands/invoke/__tests__/resolve.test.ts
@@ -257,6 +257,96 @@ describe('resolveInvokeTarget', () => {
     expect(result.runtimeArn).toContain('rt-b');
   });
 
+  describe('named runtime endpoint resolution', () => {
+    it('resolves an endpoint configured on the runtime to a qualifier', async () => {
+      const project = makeProject({
+        runtimes: [
+          {
+            name: 'my-agent',
+            build: 'CodeZip',
+            codeLocation: './agents/my-agent',
+            entrypoint: 'main.py',
+            runtimeVersion: '1.0',
+            networkMode: 'PUBLIC',
+            endpoints: { prod: { version: 2 } },
+          },
+        ] as unknown as AgentCoreProjectSpec['runtimes'],
+      });
+
+      const result = await resolveInvokeTarget({
+        project,
+        deployedState: makeDeployedState(),
+        awsTargets: makeAwsTargets(),
+        endpointName: 'prod',
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.endpoint).toBe('prod');
+    });
+
+    it('resolves an endpoint present only in deployed runtimeEndpoints', async () => {
+      const deployedState = {
+        targets: {
+          default: {
+            resources: {
+              runtimes: {
+                'my-agent': {
+                  runtimeId: 'rt-123',
+                  runtimeArn: 'arn:aws:bedrock-agentcore:us-east-1:123456789:runtime/rt-123',
+                  roleArn: 'arn:aws:iam::123456789:role/test-role',
+                },
+              },
+              runtimeEndpoints: {
+                'my-agent/staging': {
+                  endpointId: 'ep-1',
+                  endpointArn: 'arn:aws:bedrock-agentcore:us-east-1:123:runtime-endpoint/ep-1',
+                },
+              },
+            },
+          },
+        },
+      } as unknown as DeployedState;
+
+      const result = await resolveInvokeTarget({
+        project: makeProject(),
+        deployedState,
+        awsTargets: makeAwsTargets(),
+        endpointName: 'staging',
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.endpoint).toBe('staging');
+    });
+
+    it('returns ResourceNotFoundError for an unknown endpoint name', async () => {
+      const result = await resolveInvokeTarget({
+        project: makeProject(),
+        deployedState: makeDeployedState(),
+        awsTargets: makeAwsTargets(),
+        endpointName: 'nope',
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.error).toBeInstanceOf(ResourceNotFoundError);
+      expect(result.error.message).toContain("Endpoint 'nope' not found");
+    });
+
+    it('leaves endpoint undefined when no endpointName is provided', async () => {
+      const result = await resolveInvokeTarget({
+        project: makeProject(),
+        deployedState: makeDeployedState(),
+        awsTargets: makeAwsTargets(),
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.endpoint).toBeUndefined();
+    });
+  });
+
   describe('CUSTOM_JWT token resolution', () => {
     function makeJwtProject(): AgentCoreProjectSpec {
       return makeProject({

--- a/src/cli/commands/invoke/__tests__/utils.test.ts
+++ b/src/cli/commands/invoke/__tests__/utils.test.ts
@@ -1,5 +1,35 @@
-import { computeInvokeAttrs } from '../utils';
-import { describe, expect, it } from 'vitest';
+import { computeEndpointSource, computeInvokeAttrs } from '../utils';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+describe('computeEndpointSource', () => {
+  const original = process.env.AGENTCORE_RUNTIME_ENDPOINT;
+
+  beforeEach(() => {
+    delete process.env.AGENTCORE_RUNTIME_ENDPOINT;
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.AGENTCORE_RUNTIME_ENDPOINT;
+    } else {
+      process.env.AGENTCORE_RUNTIME_ENDPOINT = original;
+    }
+  });
+
+  it("returns 'flag' when the --endpoint flag is set (even if the env var is also set)", () => {
+    process.env.AGENTCORE_RUNTIME_ENDPOINT = 'staging';
+    expect(computeEndpointSource('prod')).toBe('flag');
+  });
+
+  it("returns 'env' when only the env var is set", () => {
+    process.env.AGENTCORE_RUNTIME_ENDPOINT = 'staging';
+    expect(computeEndpointSource(undefined)).toBe('env');
+  });
+
+  it("returns 'default' when neither flag nor env var is set", () => {
+    expect(computeEndpointSource(undefined)).toBe('default');
+  });
+});
 
 describe('computeInvokeAttrs', () => {
   it('returns harness when harnessName is set', () => {
@@ -76,5 +106,35 @@ describe('computeInvokeAttrs', () => {
       agentProtocol: 'MCP',
     });
     expect(attrs.agent_protocol).toBe('mcp');
+  });
+
+  it("defaults endpoint_source to 'default' when omitted", () => {
+    const attrs = computeInvokeAttrs({
+      harnessCount: 0,
+      runtimeCount: 1,
+      stream: false,
+      hasSessionId: false,
+    });
+    expect(attrs.endpoint_source).toBe('default');
+  });
+
+  it('passes through the provided endpoint_source', () => {
+    const flag = computeInvokeAttrs({
+      harnessCount: 0,
+      runtimeCount: 1,
+      stream: false,
+      hasSessionId: false,
+      endpointSource: 'flag',
+    });
+    expect(flag.endpoint_source).toBe('flag');
+
+    const env = computeInvokeAttrs({
+      harnessCount: 0,
+      runtimeCount: 1,
+      stream: false,
+      hasSessionId: false,
+      endpointSource: 'env',
+    });
+    expect(env.endpoint_source).toBe('env');
   });
 });

--- a/src/cli/commands/invoke/__tests__/utils.test.ts
+++ b/src/cli/commands/invoke/__tests__/utils.test.ts
@@ -16,7 +16,7 @@ describe('computeEndpointSource', () => {
     }
   });
 
-  it("returns 'flag' when the --endpoint flag is set (even if the env var is also set)", () => {
+  it("returns 'flag' when the --runtime-endpoint flag is set (even if the env var is also set)", () => {
     process.env.AGENTCORE_RUNTIME_ENDPOINT = 'staging';
     expect(computeEndpointSource('prod')).toBe('flag');
   });

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -289,7 +289,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     awsTargets,
     agentName: options.agentName,
     targetName: options.targetName,
-    endpointName: options.endpoint,
+    endpointName: options.runtimeEndpoint,
     bearerToken: options.bearerToken,
     sessionId: options.sessionId,
   });

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -642,6 +642,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
           logger,
           headers: options.headers,
           bearerToken: options.bearerToken,
+          endpoint,
         },
         aguiInput
       );

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -289,6 +289,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     awsTargets,
     agentName: options.agentName,
     targetName: options.targetName,
+    endpointName: options.endpoint,
     bearerToken: options.bearerToken,
     sessionId: options.sessionId,
   });
@@ -297,7 +298,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     return { success: false, error: resolved.error };
   }
 
-  const { agentSpec, targetName: selectedTargetName, targetConfig, runtimeArn, baggage } = resolved;
+  const { agentSpec, targetName: selectedTargetName, targetConfig, runtimeArn, endpoint, baggage } = resolved;
   options = {
     ...options,
     bearerToken: resolved.bearerToken ?? options.bearerToken,
@@ -714,6 +715,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
         headers: options.headers,
         bearerToken: options.bearerToken,
         baggage,
+        endpoint,
         paymentInstrumentId: options.paymentInstrumentId,
         paymentSessionId: options.paymentSessionId,
         paymentUserId: options.paymentUserId,
@@ -751,6 +753,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     headers: options.headers,
     bearerToken: options.bearerToken,
     baggage,
+    endpoint,
     paymentInstrumentId: options.paymentInstrumentId,
     paymentSessionId: options.paymentSessionId,
     paymentUserId: options.paymentUserId,

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -1,5 +1,6 @@
 import { ValidationError, serializeResult } from '../../../lib';
-import { COMMAND_DESCRIPTIONS } from '../../constants';
+import { resolveEndpointName } from '../../aws';
+import { COMMAND_DESCRIPTIONS, DEFAULT_ENDPOINT_NAME } from '../../constants';
 import { getErrorMessage } from '../../errors';
 import { ADDITIONAL_PARAMS_JSON_ERROR } from '../../primitives/constants';
 import { withCommandRunTelemetry } from '../../telemetry/cli-command-run.js';
@@ -138,6 +139,10 @@ export const registerInvoke = (program: Command) => {
       'Read the prompt from a file (for long or structured payloads that exceed shell arg limits) [non-interactive]'
     )
     .option('--runtime <name>', 'Select specific runtime [non-interactive]')
+    .option(
+      '--endpoint <name>',
+      'Target a named runtime endpoint (version alias, e.g. prod/staging). Defaults to AGENTCORE_RUNTIME_ENDPOINT env var, then DEFAULT [non-interactive]'
+    )
     .option('--gateway <name>', 'Invoke through a gateway [non-interactive]')
     .option('--gateway-target-name <name>', 'HTTP runtime target on the gateway [non-interactive]')
     .option('--target <name>', 'Select deployment target [non-interactive]')
@@ -292,6 +297,7 @@ Model & Runtime Overrides (harness only) [non-interactive]
         prompt?: string;
         promptFile?: string;
         runtime?: string;
+        endpoint?: string;
         gateway?: string;
         gatewayTargetName?: string;
         target?: string;
@@ -365,6 +371,7 @@ Model & Runtime Overrides (harness only) [non-interactive]
           cliOptions.gatewayTargetName ||
           cliOptions.stream ||
           cliOptions.runtime ||
+          cliOptions.endpoint ||
           cliOptions.gateway ||
           cliOptions.tool ||
           cliOptions.exec ||
@@ -415,9 +422,16 @@ Model & Runtime Overrides (harness only) [non-interactive]
                 }
               }
 
+              // Resolve the named endpoint: --endpoint flag → AGENTCORE_RUNTIME_ENDPOINT
+              // env var → DEFAULT. Leave it undefined for DEFAULT so the SigV4 qualifier
+              // is omitted (preserving the DEFAULT endpoint) rather than sent explicitly.
+              const resolvedEndpoint = resolveEndpointName(cliOptions.endpoint);
+              const endpoint = resolvedEndpoint === DEFAULT_ENDPOINT_NAME ? undefined : resolvedEndpoint;
+
               const options: InvokeOptions = {
                 prompt: resolved.prompt,
                 agentName: cliOptions.runtime,
+                endpoint,
                 gateway: cliOptions.gateway,
                 gatewayTarget: cliOptions.gatewayTargetName,
                 targetName: cliOptions.target ?? 'default',

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -140,7 +140,7 @@ export const registerInvoke = (program: Command) => {
     )
     .option('--runtime <name>', 'Select specific runtime [non-interactive]')
     .option(
-      '--endpoint <name>',
+      '--runtime-endpoint <name>',
       'Target a named runtime endpoint (version alias, e.g. prod/staging). Defaults to AGENTCORE_RUNTIME_ENDPOINT env var, then DEFAULT [non-interactive]'
     )
     .option('--gateway <name>', 'Invoke through a gateway [non-interactive]')
@@ -297,7 +297,7 @@ Model & Runtime Overrides (harness only) [non-interactive]
         prompt?: string;
         promptFile?: string;
         runtime?: string;
-        endpoint?: string;
+        runtimeEndpoint?: string;
         gateway?: string;
         gatewayTargetName?: string;
         target?: string;
@@ -363,14 +363,14 @@ Model & Runtime Overrides (harness only) [non-interactive]
 
         // Resolve the named endpoint once, before the CLI-mode gate, so the
         // AGENTCORE_RUNTIME_ENDPOINT env-var fallback is honored in BOTH flows:
-        // --endpoint flag → env var → DEFAULT. A non-DEFAULT resolution forces
-        // CLI mode (so `AGENTCORE_RUNTIME_ENDPOINT=staging agentcore invoke` does
-        // not silently drop into the TUI and hit DEFAULT) and is also threaded
+        // --runtime-endpoint flag → env var → DEFAULT. A non-DEFAULT resolution
+        // forces CLI mode (so `AGENTCORE_RUNTIME_ENDPOINT=staging agentcore invoke`
+        // does not silently drop into the TUI and hit DEFAULT) and is also threaded
         // into the TUI route below for interactive parity. Leave it undefined for
         // DEFAULT so the SigV4 qualifier is omitted rather than sent explicitly.
-        const resolvedEndpoint = resolveEndpointName(cliOptions.endpoint);
+        const resolvedEndpoint = resolveEndpointName(cliOptions.runtimeEndpoint);
         const endpoint = resolvedEndpoint === DEFAULT_ENDPOINT_NAME ? undefined : resolvedEndpoint;
-        const endpointSource = computeEndpointSource(cliOptions.endpoint);
+        const endpointSource = computeEndpointSource(cliOptions.runtimeEndpoint);
 
         // CLI mode if any CLI-specific options provided, prompt resolved, or prompt resolution failed
         // (follows deploy command pattern)
@@ -382,7 +382,7 @@ Model & Runtime Overrides (harness only) [non-interactive]
           cliOptions.gatewayTargetName ||
           cliOptions.stream ||
           cliOptions.runtime ||
-          cliOptions.endpoint ||
+          cliOptions.runtimeEndpoint ||
           endpoint !== undefined ||
           cliOptions.gateway ||
           cliOptions.tool ||
@@ -438,7 +438,7 @@ Model & Runtime Overrides (harness only) [non-interactive]
               const options: InvokeOptions = {
                 prompt: resolved.prompt,
                 agentName: cliOptions.runtime,
-                endpoint,
+                runtimeEndpoint: endpoint,
                 gateway: cliOptions.gateway,
                 gatewayTarget: cliOptions.gatewayTargetName,
                 targetName: cliOptions.target ?? 'default',

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -10,7 +10,7 @@ import { parseHeaderFlags } from '../shared/header-utils';
 import { type InvokeContext, handleHarnessInvokeByArn, handleInvoke, loadInvokeConfig } from './action';
 import { resolvePrompt } from './resolve-prompt';
 import type { InvokeOptions, InvokeResult } from './types';
-import { computeInvokeAttrs } from './utils';
+import { computeEndpointSource, computeInvokeAttrs } from './utils';
 import { validateInvokeOptions } from './validate';
 import type { Command } from '@commander-js/extra-typings';
 import { Text, render } from 'ink';
@@ -361,6 +361,17 @@ Model & Runtime Overrides (harness only) [non-interactive]
           stdinPiped: !process.stdin.isTTY,
         });
 
+        // Resolve the named endpoint once, before the CLI-mode gate, so the
+        // AGENTCORE_RUNTIME_ENDPOINT env-var fallback is honored in BOTH flows:
+        // --endpoint flag → env var → DEFAULT. A non-DEFAULT resolution forces
+        // CLI mode (so `AGENTCORE_RUNTIME_ENDPOINT=staging agentcore invoke` does
+        // not silently drop into the TUI and hit DEFAULT) and is also threaded
+        // into the TUI route below for interactive parity. Leave it undefined for
+        // DEFAULT so the SigV4 qualifier is omitted rather than sent explicitly.
+        const resolvedEndpoint = resolveEndpointName(cliOptions.endpoint);
+        const endpoint = resolvedEndpoint === DEFAULT_ENDPOINT_NAME ? undefined : resolvedEndpoint;
+        const endpointSource = computeEndpointSource(cliOptions.endpoint);
+
         // CLI mode if any CLI-specific options provided, prompt resolved, or prompt resolution failed
         // (follows deploy command pattern)
         if (
@@ -372,6 +383,7 @@ Model & Runtime Overrides (harness only) [non-interactive]
           cliOptions.stream ||
           cliOptions.runtime ||
           cliOptions.endpoint ||
+          endpoint !== undefined ||
           cliOptions.gateway ||
           cliOptions.tool ||
           cliOptions.exec ||
@@ -396,6 +408,7 @@ Model & Runtime Overrides (harness only) [non-interactive]
               hasSessionId: !!cliOptions.sessionId,
               bearerToken: cliOptions.bearerToken,
               agentProtocol: agentProtocol ?? (cliOptions.tool ? 'mcp' : undefined),
+              endpointSource,
             }),
             async (): Promise<InvokeResult> => {
               if (!resolved.success) {
@@ -421,12 +434,6 @@ Model & Runtime Overrides (harness only) [non-interactive]
                   process.exit(1);
                 }
               }
-
-              // Resolve the named endpoint: --endpoint flag → AGENTCORE_RUNTIME_ENDPOINT
-              // env var → DEFAULT. Leave it undefined for DEFAULT so the SigV4 qualifier
-              // is omitted (preserving the DEFAULT endpoint) rather than sent explicitly.
-              const resolvedEndpoint = resolveEndpointName(cliOptions.endpoint);
-              const endpoint = resolvedEndpoint === DEFAULT_ENDPOINT_NAME ? undefined : resolvedEndpoint;
 
               const options: InvokeOptions = {
                 prompt: resolved.prompt,
@@ -506,6 +513,8 @@ Model & Runtime Overrides (harness only) [non-interactive]
               name: 'invoke',
               sessionId: cliOptions.sessionId,
               userId: cliOptions.userId,
+              endpoint,
+              endpointSource,
               headers,
               bearerToken: cliOptions.bearerToken,
               paymentInstrumentId: cliOptions.paymentInstrumentId,

--- a/src/cli/commands/invoke/resolve.ts
+++ b/src/cli/commands/invoke/resolve.ts
@@ -16,6 +16,8 @@ export interface ResolveInvokeInput {
   awsTargets: AwsDeploymentTargets;
   agentName?: string;
   targetName?: string;
+  /** Named runtime endpoint (version alias) to target. When omitted, the DEFAULT endpoint is used. */
+  endpointName?: string;
   bearerToken?: string;
   sessionId?: string;
   configIO?: ConfigIO;
@@ -27,6 +29,8 @@ export interface ResolvedInvokeTarget {
   targetConfig: AwsDeploymentTarget;
   region: string;
   runtimeArn: string;
+  /** Resolved runtime endpoint qualifier (the endpoint NAME). Undefined targets the DEFAULT endpoint. */
+  endpoint?: string;
   bearerToken?: string;
   sessionId?: string;
   baggage?: string;
@@ -99,6 +103,39 @@ export async function resolveInvokeTarget(input: ResolveInvokeInput): Promise<Re
     };
   }
 
+  // Resolve the optional named runtime endpoint (version alias) to its qualifier
+  // (the endpoint NAME, which is what the InvokeAgentRuntime API expects). Validate
+  // against the configured endpoints and/or the deployed runtimeEndpoints so an
+  // unknown name fails fast instead of silently hitting DEFAULT.
+  let endpoint: string | undefined;
+  if (input.endpointName) {
+    const configured = agentSpec.endpoints ?? {};
+    const deployedEndpoints = targetState?.resources?.runtimeEndpoints ?? {};
+    const isConfigured = Object.prototype.hasOwnProperty.call(configured, input.endpointName);
+    const isDeployed = Object.prototype.hasOwnProperty.call(
+      deployedEndpoints,
+      `${agentSpec.name}/${input.endpointName}`
+    );
+    if (!isConfigured && !isDeployed) {
+      const available = Array.from(
+        new Set([
+          ...Object.keys(configured),
+          ...Object.keys(deployedEndpoints)
+            .filter(k => k.startsWith(`${agentSpec.name}/`))
+            .map(k => k.slice(`${agentSpec.name}/`.length)),
+        ])
+      );
+      return {
+        success: false,
+        error: new ResourceNotFoundError(
+          `Endpoint '${input.endpointName}' not found for agent '${agentSpec.name}'.` +
+            (available.length > 0 ? ` Available: ${available.join(', ')}` : '')
+        ),
+      };
+    }
+    endpoint = input.endpointName;
+  }
+
   // Build config bundle baggage if a bundle is associated with this agent
   const deployedBundles = targetState?.resources?.configBundles ?? {};
   let baggage: string | undefined;
@@ -157,6 +194,7 @@ export async function resolveInvokeTarget(input: ResolveInvokeInput): Promise<Re
     targetConfig,
     region: targetConfig.region,
     runtimeArn: agentState.runtimeArn,
+    endpoint,
     bearerToken,
     sessionId,
     baggage,

--- a/src/cli/commands/invoke/types.ts
+++ b/src/cli/commands/invoke/types.ts
@@ -11,6 +11,8 @@ export interface InvokeOptions {
   gatewayTarget?: string;
   /** AWS region (used with --harness-arn) */
   region?: string;
+  /** Named runtime endpoint (version alias) to target, e.g. prod/staging. Defaults to DEFAULT. */
+  endpoint?: string;
   targetName?: string;
   prompt?: string;
   /** Path to a file containing the prompt (alternative to --prompt / positional) */

--- a/src/cli/commands/invoke/types.ts
+++ b/src/cli/commands/invoke/types.ts
@@ -12,7 +12,7 @@ export interface InvokeOptions {
   /** AWS region (used with --harness-arn) */
   region?: string;
   /** Named runtime endpoint (version alias) to target, e.g. prod/staging. Defaults to DEFAULT. */
-  endpoint?: string;
+  runtimeEndpoint?: string;
   targetName?: string;
   prompt?: string;
   /** Path to a file containing the prompt (alternative to --prompt / positional) */

--- a/src/cli/commands/invoke/utils.ts
+++ b/src/cli/commands/invoke/utils.ts
@@ -1,4 +1,10 @@
-import { AgentEnvironment, AgentProtocol, AuthType, standardize } from '../../telemetry/schemas/common-shapes.js';
+import {
+  AgentEnvironment,
+  AgentProtocol,
+  AuthType,
+  EndpointSource,
+  standardize,
+} from '../../telemetry/schemas/common-shapes.js';
 
 function isHarnessInvoke(options: {
   harnessName?: string;
@@ -11,6 +17,17 @@ function isHarnessInvoke(options: {
   return false;
 }
 
+/**
+ * Classify where the resolved invoke endpoint qualifier came from for telemetry:
+ * the explicit --endpoint flag, the AGENTCORE_RUNTIME_ENDPOINT env var, or the
+ * implicit DEFAULT endpoint when neither is set.
+ */
+export function computeEndpointSource(flagEndpoint?: string): 'flag' | 'env' | 'default' {
+  if (flagEndpoint) return 'flag';
+  if (process.env.AGENTCORE_RUNTIME_ENDPOINT) return 'env';
+  return 'default';
+}
+
 export function computeInvokeAttrs(options: {
   harnessName?: string;
   harnessArn?: string;
@@ -20,6 +37,7 @@ export function computeInvokeAttrs(options: {
   hasSessionId: boolean;
   bearerToken?: string;
   agentProtocol?: string;
+  endpointSource?: 'flag' | 'env' | 'default';
 }) {
   const isHarness = isHarnessInvoke(options);
   return {
@@ -28,5 +46,6 @@ export function computeInvokeAttrs(options: {
     has_session_id: options.hasSessionId,
     auth_type: standardize(AuthType, options.bearerToken ? 'bearer_token' : 'sigv4'),
     agent_protocol: isHarness ? undefined : standardize(AgentProtocol, options.agentProtocol ?? 'http'),
+    endpoint_source: standardize(EndpointSource, options.endpointSource ?? 'default'),
   };
 }

--- a/src/cli/telemetry/schemas/command-run.ts
+++ b/src/cli/telemetry/schemas/command-run.ts
@@ -12,6 +12,7 @@ import {
   CredentialType,
   DeployModeSchema,
   DevAction,
+  EndpointSource,
   EvaluatorLevel,
   EvaluatorType,
   FilterState,
@@ -137,6 +138,7 @@ const InvokeAttrs = safeSchema({
   has_session_id: z.boolean(),
   auth_type: AuthType,
   agent_protocol: AgentProtocol.optional(),
+  endpoint_source: EndpointSource,
 });
 
 const ExecAttrs = safeSchema({

--- a/src/cli/telemetry/schemas/common-shapes.ts
+++ b/src/cli/telemetry/schemas/common-shapes.ts
@@ -32,6 +32,8 @@ export const UiMode = z.enum(['browser', 'terminal']);
 export const AgentSource = z.enum(['create', 'byo', 'import']);
 export const AttachMode = z.enum(['log_only', 'enforce']);
 export const AuthType = z.enum(['sigv4', 'bearer_token']);
+/** Where the invoke --endpoint qualifier came from: the --endpoint flag, the AGENTCORE_RUNTIME_ENDPOINT env var, or the implicit DEFAULT endpoint. */
+export const EndpointSource = z.enum(['flag', 'env', 'default']);
 export const AuthorizerType = z.enum(['aws_iam', 'custom_jwt', 'none']);
 export const BuildType = z.enum(['codezip', 'container']);
 export const CredentialType = z.enum(['api-key', 'oauth']);

--- a/src/cli/tui/App.tsx
+++ b/src/cli/tui/App.tsx
@@ -43,6 +43,10 @@ type Route =
       name: 'invoke';
       sessionId?: string;
       userId?: string;
+      /** Resolved named runtime endpoint (version alias) to target. Undefined targets DEFAULT. */
+      endpoint?: string;
+      /** Where the resolved endpoint came from, for telemetry. */
+      endpointSource?: 'flag' | 'env' | 'default';
       headers?: Record<string, string>;
       bearerToken?: string;
       isResume?: boolean;
@@ -248,6 +252,8 @@ function AppContent({
         initialSessionId={route.sessionId}
         isResume={route.isResume}
         initialUserId={route.userId}
+        initialEndpoint={route.endpoint}
+        initialEndpointSource={route.endpointSource}
         initialHeaders={route.headers}
         initialBearerToken={route.bearerToken}
         onExec={result => {

--- a/src/cli/tui/screens/invoke/InvokeScreen.tsx
+++ b/src/cli/tui/screens/invoke/InvokeScreen.tsx
@@ -14,6 +14,10 @@ interface InvokeScreenProps {
   initialPrompt?: string;
   initialSessionId?: string;
   initialUserId?: string;
+  /** Resolved named runtime endpoint (version alias) to target on every invocation. Undefined targets DEFAULT. */
+  initialEndpoint?: string;
+  /** Where the resolved endpoint came from, for telemetry. */
+  initialEndpointSource?: 'flag' | 'env' | 'default';
   /** Custom headers to forward to the agent runtime on every invocation */
   initialHeaders?: Record<string, string>;
   initialBearerToken?: string;
@@ -155,6 +159,8 @@ export function InvokeScreen({
   initialPrompt,
   initialSessionId,
   initialUserId,
+  initialEndpoint,
+  initialEndpointSource,
   initialHeaders,
   initialBearerToken,
   onExec,
@@ -189,6 +195,8 @@ export function InvokeScreen({
   } = useInvokeFlow({
     initialSessionId,
     initialUserId,
+    initialEndpoint,
+    initialEndpointSource,
     headers: initialHeaders,
     initialBearerToken,
     isResume,

--- a/src/cli/tui/screens/invoke/useInvokeFlow.ts
+++ b/src/cli/tui/screens/invoke/useInvokeFlow.ts
@@ -675,6 +675,7 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
               logger,
               headers,
               bearerToken: bearerToken || undefined,
+              endpoint: initialEndpoint,
             },
             aguiInput
           );

--- a/src/cli/tui/screens/invoke/useInvokeFlow.ts
+++ b/src/cli/tui/screens/invoke/useInvokeFlow.ts
@@ -69,6 +69,10 @@ export interface InvokeConfig {
 export interface InvokeFlowOptions {
   initialSessionId?: string;
   initialUserId?: string;
+  /** Resolved named runtime endpoint (version alias) to target on every invocation. Undefined targets DEFAULT. */
+  initialEndpoint?: string;
+  /** Where the resolved endpoint came from, for telemetry. */
+  initialEndpointSource?: 'flag' | 'env' | 'default';
   /** Custom headers to forward to the agent runtime on every invocation */
   headers?: Record<string, string>;
   initialBearerToken?: string;
@@ -121,6 +125,8 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
   const {
     initialSessionId,
     initialUserId,
+    initialEndpoint,
+    initialEndpointSource,
     headers,
     initialBearerToken,
     isResume,
@@ -183,6 +189,7 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
           hasSessionId: !!initialSessionId,
           bearerToken: initialBearerToken,
           agentProtocol: firstProtocol,
+          endpointSource: initialEndpointSource,
         }),
         async () => {
           if (!project) {
@@ -790,6 +797,7 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
               region: config.target.region,
               runtimeArn: agent.state.runtimeArn,
               payload: prompt,
+              endpoint: initialEndpoint,
               sessionId: sessionId ?? undefined,
               userId,
               logger,
@@ -850,6 +858,7 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
       fetchMcpTools,
       getMcpInvokeOptions,
       streamHarnessInvoke,
+      initialEndpoint,
       initialPaymentInstrumentId,
       initialPaymentUserId,
     ]


### PR DESCRIPTION
Refs aws/agentcore-cli#986
Refs aws/agentcore-cli#1554

## Issues
- **#986** — `agentcore invoke` has no `--endpoint` flag, so users who create named runtime endpoints (version aliases like `prod`/`staging` via `agentcore add runtime-endpoint`) cannot target a specific endpoint from the CLI — invoke always hits the DEFAULT endpoint over SigV4. This is a missing-convenience feature gap, not a malfunction: a complete workaround exists today via `--bearer-token` (whose path already threads the endpoint qualifier) or by calling the API directly with `qualifier`.
- **#1554** — `agentcore invoke` can only ever hit a runtime's DEFAULT endpoint; there is no `--endpoint` flag, so named runtime endpoints created via `agentcore add runtime-endpoint` (e.g. control/treatment version aliases for A/B testing) cannot be smoke-tested directly. The only workaround is routing through a gateway. As a bonus, the same SigV4-qualifier gap means `run eval --dataset --endpoint <name>` against a SigV4 agent silently invokes DEFAULT while reading spans from the named-endpoint log group, so it can collect zero spans.

## Root cause
The endpoint/qualifier is never carried from the CLI surface through resolution into the SigV4 SDK call. Verified at v0.20.2: no --endpoint registered on invoke (command.tsx:128-200); no endpoint field on InvokeOptions (types.ts:3-75); resolveInvokeTarget neither accepts nor returns one and ResolvedInvokeTarget has no endpoint field (resolve.ts:24-33,37-164); action.ts calls invokeAgentRuntimeStreaming (710) and invokeAgentRuntime (748) without passing endpoint; the SigV4 InvokeAgentRuntimeCommand is built without qualifier at agentcore.ts:362 and :458 even though InvokeAgentRuntimeOptions.endpoint exists (agentcore.ts:74) and the bearer-token path honors it via buildInvokeUrl (agentcore.ts:203-204). Premise real: deploy persists endpoints to runtimeEndpoints keyed ${agentName}/${endpointName} (outputs.ts:498); runtimes[].endpoints[name] modeled (agent-env.ts:345-346).

See root_cause field: verified at v0.20.2 HEAD e92c79a4. invoke has no --endpoint (command.tsx/types.ts/action.ts), and the SigV4 InvokeAgentRuntimeCommand at agentcore.ts:362-370 & 458-466 omits the SDK-supported `qualifier` (models_0.d.ts:390-393); endpoint is only honored in the bearer path (buildInvokeUrl, agentcore.ts:201-205). Latent same-cause bug at scenario-executor.ts:75.

## The fix
Add `--endpoint <name>` to invoke and plumb it through to the SDK qualifier. (1) Register the flag in command.tsx and add it to cliOptions/InvokeOptions (types.ts). (2) In resolveInvokeTarget (resolve.ts), accept an endpointName, validate it against project.runtimes[].endpoints[name] and/or deployedState...runtimeEndpoints[`${agent}/${name}`], and return it as endpoint/qualifier. (3) Pass endpoint into both invokeAgentRuntime (action.ts:748) and invokeAgentRuntimeStreaming (action.ts:710). (4) In agentcore.ts, add `...(options.endpoint && { qualifier: options.endpoint })` to the two SigV4 InvokeAgentRuntimeCommand builders (lines 362 and 458). DESIGN NOTE confirmed in SDK: the AWS InvokeAgentRuntime API targets endpoints via `qualifier`, which is the endpoint NAME, not the ARN (@aws-sdk/client-bedrock-agentcore models_0.d.ts:390-393: "an endpoint name that points to a specific version"); the runtime ARN is unchanged and deployed-state is used only to validate existence. The issue body's wording ("resolve the endpoint ARN and route to it") is technically loose. Also mirror this in the invoke TUI flow (useInvokeFlow.ts) for parity.

See the_fix field: register --endpoint on invoke, thread through InvokeOptions->action, AND set `qualifier: options.endpoint` on the SigV4 InvokeAgentRuntimeCommand (agentcore.ts:362-370,458-466). Reuse existing resolveEndpointName (cloudwatch.ts:9-11) for the AGENTCORE_RUNTIME_ENDPOINT fallback rather than re-implementing it at the command layer.

_Files touched:_ src/cli/commands/invoke/command.tsx (register --endpoint, thread into InvokeOptions ~128-200, 425-462); src/cli/commands/invoke/types.ts (add endpoint to InvokeOptions ~3-75); src/cli/commands/invoke/resolve.ts (resolveInvokeTarget: accept+validate, return qualifier ~24-33,37-164); src/cli/commands/invoke/action.ts (pass endpoint into invokeAgentRuntime/Streaming ~710,748); src/cli/aws/agentcore.ts (add qualifier to both SigV4 InvokeAgentRuntimeCommand builders, lines 362 and 458). Optional parity: src/cli/tui/screens/invoke/useInvokeFlow.ts.

CLI only. src/cli/commands/invoke/command.tsx (register --endpoint, cliOptions type, options object); src/cli/commands/invoke/types.ts (add endpoint to InvokeOptions); src/cli/commands/invoke/action.ts (thread endpoint into invokeAgentRuntime / invokeAgentRuntimeStreaming, ~710-760); src/cli/aws/agentcore.ts (add qualifier: options.endpoint to InvokeAgentRuntimeCommand at 362-370 and 458-466 — the SigV4 fix; optionally MCP/A2A/AGUI builders too); reuse src/cli/aws/cloudwatch.ts resolveEndpointName for the env fallback. Note: run eval's --endpoint is registered in src/cli/commands/run/command.tsx (lines 92, 209), NOT commands/eval/ as the brief stated.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (base HEAD, confirmed via git show): src/cli/commands/invoke/command.tsx has NO --endpoint flag, so `agentcore invoke --endpoint prod "hi"` would hit Commander's "error: unknown option '--endpoint'" (reproduced live: `invoke --bogusflag` -> "error: unknown option '--bogusflag'"); InvokeOptions in types.ts has NO endpoint field; and the SigV4 InvokeAgentRuntimeCommand at agentcore.ts ~362 (streaming) and ~459 (non-streaming) was constructed WITHOUT any qualifier, so every SigV4 invoke silently hit DEFAULT even though the bearer-token path already encoded ?qualifier= in buildInvokeUrl. AFTER (fix branch, rebuilt clean -> dist/cli/index.mjs): built `invoke --help` now lists `--endpoint <name>  Target a named runtime endpoint (version alias, e.g. prod/staging)...`; `node dist/cli/index.mjs invoke --endpoint prod "hi"` parses cleanly (proceeds to "No agentcore project found" instead of "unknown option"). New unit file src/cli/aws/__tests__/agentcore-invoke-qualifier.test.ts (4 tests) proves both streaming and non-streaming commands carry qualifier:'prod'/'staging' when endpoint set and OMIT qualifier when unset. resolve.test.ts "named runtime endpoint resolution" (4 tests) proves: configured endpoints[].prod -> endpoint='prod'; deployed-only runtimeEndpoints['my-agent/staging'] -> endpoint='staging'; unknown 'nope' -> success:false ResourceNotFoundError "Endpoint 'nope' not found"; absent endpointName -> endpoint undefined. action.ts threads resolved+validated `endpoint` in

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
