### PR TITLE
fix(cli): Add requireTTY() before each unguarded interactive TUI la... (#982)

### DIFF
--- a/src/cli/commands/dev/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/dev/__tests__/tty-guard.test.ts
@@ -1,0 +1,84 @@
+import { launchTuiDevScreenWithPicker } from '../browser-mode';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Drive the REAL requireTTY by toggling process.stdin.isTTY / process.stdout.isTTY
+// and spying on process.exit / console.error. Only the I/O boundaries are mocked:
+// the Ink renderer and the DevScreen the picker renders. This pins the guard that
+// PR #1640 centralized — the browser-mode harness picker must refuse to render in a
+// non-TTY context instead of throwing Ink's "Raw mode is not supported" stack trace.
+const mockRender = vi.fn((..._args: unknown[]) => ({
+  unmount: vi.fn(),
+  waitUntilExit: () => Promise.resolve(),
+}));
+
+vi.mock('ink', () => ({
+  render: (...args: unknown[]) => mockRender(...args),
+}));
+
+vi.mock('../../../tui/screens/dev/DevScreen', () => ({ DevScreen: () => null }));
+
+describe('dev browser-mode picker TTY guard', () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>;
+  const origStdinIsTTY = process.stdin.isTTY;
+  const origStdoutIsTTY = process.stdout.isTTY;
+
+  beforeEach(() => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.stdin.isTTY = origStdinIsTTY;
+    process.stdout.isTTY = origStdoutIsTTY;
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    stdoutWriteSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('exits with code 1 and never renders in a non-TTY context', async () => {
+    process.stdin.isTTY = false;
+    process.stdout.isTTY = false;
+
+    await expect(launchTuiDevScreenWithPicker('/tmp/project')).rejects.toThrow('process.exit(1)');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('requires an interactive terminal'));
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('exits when only stdin is not a TTY', async () => {
+    process.stdin.isTTY = false;
+    process.stdout.isTTY = true;
+
+    await expect(launchTuiDevScreenWithPicker('/tmp/project')).rejects.toThrow('process.exit(1)');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('exits when only stdout is not a TTY', async () => {
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = false;
+
+    await expect(launchTuiDevScreenWithPicker('/tmp/project')).rejects.toThrow('process.exit(1)');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('renders the picker when both stdin and stdout are TTYs', async () => {
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+
+    await launchTuiDevScreenWithPicker('/tmp/project');
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(mockRender).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/dev/browser-mode.ts
+++ b/src/cli/commands/dev/browser-mode.ts
@@ -15,6 +15,7 @@ import { listMemoryRecords, retrieveMemoryRecords } from '../../operations/memor
 import { loadDeployedProjectConfig, resolveAgentOrHarness } from '../../operations/resolve-agent';
 import { fetchTraceRecords, listTraces } from '../../operations/traces';
 import { LayoutProvider } from '../../tui/context';
+import { requireTTY } from '../../tui/guards';
 import { runCliDeploy } from '../deploy/progress';
 import { render } from 'ink';
 import path from 'node:path';
@@ -328,6 +329,7 @@ export async function launchTuiDevScreenWithPicker(
   workingDir: string,
   options?: { skipDeploy?: boolean }
 ): Promise<TuiPickerResult | undefined> {
+  requireTTY();
   process.stdout.write(ENTER_ALT_SCREEN);
 
   const exitAltScreen = () => {

--- a/src/cli/commands/export/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/export/__tests__/tty-guard.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // console.error. Only the I/O boundaries renderTUI touches are mocked: the
 // Ink renderer, telemetry, and post-command notices. The guard runs first in
 // renderTUI, so a non-TTY context exits before any of these are reached.
-const mockRender = vi.fn(() => ({ waitUntilExit: () => Promise.resolve() }));
+const mockRender = vi.fn((..._args: unknown[]) => ({ waitUntilExit: () => Promise.resolve() }));
 
 vi.mock('ink', () => ({
   render: (...args: unknown[]) => mockRender(...args),
@@ -28,9 +28,9 @@ describe('export harness TTY guard', () => {
   let program: Command;
   let exitSpy: ReturnType<typeof vi.spyOn>;
   let errorSpy: ReturnType<typeof vi.spyOn>;
+  let writeSpy: ReturnType<typeof vi.spyOn>;
   const origStdinIsTTY = process.stdin.isTTY;
   const origStdoutIsTTY = process.stdout.isTTY;
-  const origWrite = process.stdout.write;
 
   beforeEach(() => {
     program = new Command();
@@ -38,7 +38,7 @@ describe('export harness TTY guard', () => {
     registerExport(program);
 
     // Swallow the alt-screen escape sequences renderTUI writes on the TTY path.
-    process.stdout.write = vi.fn().mockReturnValue(true) as unknown as typeof process.stdout.write;
+    writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
     exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
       throw new Error(`process.exit(${code})`);
     });
@@ -48,7 +48,7 @@ describe('export harness TTY guard', () => {
   afterEach(() => {
     process.stdin.isTTY = origStdinIsTTY;
     process.stdout.isTTY = origStdoutIsTTY;
-    process.stdout.write = origWrite;
+    writeSpy.mockRestore();
     exitSpy.mockRestore();
     errorSpy.mockRestore();
     vi.clearAllMocks();

--- a/src/cli/commands/export/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/export/__tests__/tty-guard.test.ts
@@ -1,0 +1,46 @@
+import { registerExport } from '../index';
+import { Command } from '@commander-js/extra-typings';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireTTY = vi.fn();
+const mockRenderTUI = vi.fn();
+
+vi.mock('../../../tui/guards', () => ({
+  requireTTY: () => mockRequireTTY(),
+}));
+
+vi.mock('../../../tui/render', () => ({
+  renderTUI: (...args: unknown[]) => mockRenderTUI(...args),
+}));
+
+describe('export harness TTY guard', () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    registerExport(program);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('calls requireTTY and never renders the TUI in a non-TTY context', async () => {
+    mockRequireTTY.mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+
+    await expect(program.parseAsync(['export', 'harness'], { from: 'user' })).rejects.toThrow('process.exit');
+
+    expect(mockRequireTTY).toHaveBeenCalled();
+    expect(mockRenderTUI).not.toHaveBeenCalled();
+  });
+
+  it('renders the TUI when a TTY is present', async () => {
+    await program.parseAsync(['export', 'harness'], { from: 'user' });
+
+    expect(mockRequireTTY).toHaveBeenCalled();
+    expect(mockRenderTUI).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/export/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/export/__tests__/tty-guard.test.ts
@@ -2,45 +2,86 @@ import { registerExport } from '../index';
 import { Command } from '@commander-js/extra-typings';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockRequireTTY = vi.fn();
-const mockRenderTUI = vi.fn();
+// Drive the REAL requireTTY (centralized inside renderTUI) by toggling
+// process.stdin.isTTY / process.stdout.isTTY and spying on process.exit /
+// console.error. Only the I/O boundaries renderTUI touches are mocked: the
+// Ink renderer, telemetry, and post-command notices. The guard runs first in
+// renderTUI, so a non-TTY context exits before any of these are reached.
+const mockRender = vi.fn(() => ({ waitUntilExit: () => Promise.resolve() }));
 
-vi.mock('../../../tui/guards', () => ({
-  requireTTY: () => mockRequireTTY(),
+vi.mock('ink', () => ({
+  render: (...args: unknown[]) => mockRender(...args),
 }));
 
-vi.mock('../../../tui/render', () => ({
-  renderTUI: (...args: unknown[]) => mockRenderTUI(...args),
+vi.mock('../../../telemetry', () => ({
+  TelemetryClientAccessor: {
+    init: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+vi.mock('../../../notices', () => ({
+  printPostCommandNotices: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe('export harness TTY guard', () => {
   let program: Command;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  const origStdinIsTTY = process.stdin.isTTY;
+  const origStdoutIsTTY = process.stdout.isTTY;
+  const origWrite = process.stdout.write;
 
   beforeEach(() => {
     program = new Command();
     program.exitOverride();
     registerExport(program);
+
+    // Swallow the alt-screen escape sequences renderTUI writes on the TTY path.
+    process.stdout.write = vi.fn().mockReturnValue(true) as unknown as typeof process.stdout.write;
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    vi.resetAllMocks();
+    process.stdin.isTTY = origStdinIsTTY;
+    process.stdout.isTTY = origStdoutIsTTY;
+    process.stdout.write = origWrite;
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
   });
 
-  it('calls requireTTY and never renders the TUI in a non-TTY context', async () => {
-    mockRequireTTY.mockImplementation(() => {
-      throw new Error('process.exit');
-    });
+  it('exits with code 1 and never renders the TUI in a non-TTY context', async () => {
+    process.stdin.isTTY = false;
+    process.stdout.isTTY = false;
 
-    await expect(program.parseAsync(['export', 'harness'], { from: 'user' })).rejects.toThrow('process.exit');
+    await expect(program.parseAsync(['export', 'harness'], { from: 'user' })).rejects.toThrow('process.exit(1)');
 
-    expect(mockRequireTTY).toHaveBeenCalled();
-    expect(mockRenderTUI).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('requires an interactive terminal'));
+    expect(mockRender).not.toHaveBeenCalled();
   });
 
-  it('renders the TUI when a TTY is present', async () => {
+  it('exits when only stdout is not a TTY', async () => {
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = false;
+
+    await expect(program.parseAsync(['export', 'harness'], { from: 'user' })).rejects.toThrow('process.exit(1)');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('renders the TUI when both stdin and stdout are TTYs', async () => {
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+
     await program.parseAsync(['export', 'harness'], { from: 'user' });
 
-    expect(mockRequireTTY).toHaveBeenCalled();
-    expect(mockRenderTUI).toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(mockRender).toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/export/index.ts
+++ b/src/cli/commands/export/index.ts
@@ -1,6 +1,5 @@
 import { serializeResult } from '../../../lib/result';
 import { ANSI, COMMAND_DESCRIPTIONS } from '../../constants';
-import { requireTTY } from '../../tui/guards';
 import { renderTUI } from '../../tui/render';
 import { handleExportHarness } from './harness-action';
 import type { Command } from '@commander-js/extra-typings';
@@ -30,7 +29,7 @@ export function registerExport(program: Command): void {
           console.log(JSON.stringify({ success: false, error: '--name is required in non-interactive mode' }));
           process.exit(1);
         }
-        requireTTY();
+        // renderTUI() guards for an interactive terminal before rendering.
         await renderTUI({ initialRoute: { name: 'export-harness' }, actionOnBack: 'exit' });
         return;
       }

--- a/src/cli/commands/export/index.ts
+++ b/src/cli/commands/export/index.ts
@@ -1,5 +1,6 @@
 import { serializeResult } from '../../../lib/result';
 import { ANSI, COMMAND_DESCRIPTIONS } from '../../constants';
+import { requireTTY } from '../../tui/guards';
 import { renderTUI } from '../../tui/render';
 import { handleExportHarness } from './harness-action';
 import type { Command } from '@commander-js/extra-typings';
@@ -29,6 +30,7 @@ export function registerExport(program: Command): void {
           console.log(JSON.stringify({ success: false, error: '--name is required in non-interactive mode' }));
           process.exit(1);
         }
+        requireTTY();
         await renderTUI({ initialRoute: { name: 'export-harness' }, actionOnBack: 'exit' });
         return;
       }

--- a/src/cli/commands/import/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/import/__tests__/tty-guard.test.ts
@@ -1,0 +1,56 @@
+import { registerImport } from '../command';
+import { Command } from '@commander-js/extra-typings';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireTTY = vi.fn();
+const mockRequireProject = vi.fn();
+const mockRender = vi.fn();
+
+vi.mock('../../../tui/guards/tty', () => ({
+  requireTTY: () => mockRequireTTY(),
+}));
+
+vi.mock('../../../tui/guards/project', () => ({
+  requireProject: () => mockRequireProject(),
+}));
+
+vi.mock('ink', () => ({
+  render: (...args: unknown[]) => {
+    mockRender(...args);
+    return { clear: vi.fn(), unmount: vi.fn() };
+  },
+}));
+
+vi.mock('../../../tui/screens/import', () => ({ ImportFlow: () => null }));
+
+describe('import non-source TTY guard', () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    registerImport(program);
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('calls requireTTY and does not render when the guard exits in a non-TTY context', async () => {
+    mockRequireTTY.mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+
+    await expect(program.parseAsync(['import'], { from: 'user' })).rejects.toThrow('process.exit');
+
+    expect(mockRequireTTY).toHaveBeenCalled();
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('renders the interactive flow when a TTY is present', async () => {
+    await program.parseAsync(['import'], { from: 'user' });
+
+    expect(mockRequireTTY).toHaveBeenCalled();
+    expect(mockRender).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/import/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/import/__tests__/tty-guard.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // and spying on process.exit / console.error. Only the I/O boundaries are mocked:
 // the Ink renderer and the ImportFlow screen. requireProject is stubbed to a no-op
 // so the TTY guard (which runs after it) is what we exercise here.
-const mockRender = vi.fn(() => ({ clear: vi.fn(), unmount: vi.fn() }));
+const mockRender = vi.fn((..._args: unknown[]) => ({ clear: vi.fn(), unmount: vi.fn() }));
 
 vi.mock('../../../tui/guards', async importOriginal => {
   const actual = await importOriginal<typeof import('../../../tui/guards')>();

--- a/src/cli/commands/import/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/import/__tests__/tty-guard.test.ts
@@ -2,55 +2,80 @@ import { registerImport } from '../command';
 import { Command } from '@commander-js/extra-typings';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockRequireTTY = vi.fn();
-const mockRequireProject = vi.fn();
-const mockRender = vi.fn();
+// Drive the REAL requireTTY by toggling process.stdin.isTTY / process.stdout.isTTY
+// and spying on process.exit / console.error. Only the I/O boundaries are mocked:
+// the Ink renderer and the ImportFlow screen. requireProject is stubbed to a no-op
+// so the TTY guard (which runs after it) is what we exercise here.
+const mockRender = vi.fn(() => ({ clear: vi.fn(), unmount: vi.fn() }));
 
-vi.mock('../../../tui/guards/tty', () => ({
-  requireTTY: () => mockRequireTTY(),
-}));
-
-vi.mock('../../../tui/guards/project', () => ({
-  requireProject: () => mockRequireProject(),
-}));
+vi.mock('../../../tui/guards', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../tui/guards')>();
+  return {
+    ...actual,
+    requireProject: vi.fn(),
+  };
+});
 
 vi.mock('ink', () => ({
-  render: (...args: unknown[]) => {
-    mockRender(...args);
-    return { clear: vi.fn(), unmount: vi.fn() };
-  },
+  render: (...args: unknown[]) => mockRender(...args),
 }));
 
 vi.mock('../../../tui/screens/import', () => ({ ImportFlow: () => null }));
 
 describe('import non-source TTY guard', () => {
   let program: Command;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  const origStdinIsTTY = process.stdin.isTTY;
+  const origStdoutIsTTY = process.stdout.isTTY;
 
   beforeEach(() => {
     program = new Command();
     program.exitOverride();
     registerImport(program);
+
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+      throw new Error(`process.exit(${code})`);
+    });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    vi.resetAllMocks();
+    process.stdin.isTTY = origStdinIsTTY;
+    process.stdout.isTTY = origStdoutIsTTY;
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.clearAllMocks();
   });
 
-  it('calls requireTTY and does not render when the guard exits in a non-TTY context', async () => {
-    mockRequireTTY.mockImplementation(() => {
-      throw new Error('process.exit');
-    });
+  it('exits with code 1 and does not render in a non-TTY context', async () => {
+    process.stdin.isTTY = false;
+    process.stdout.isTTY = false;
 
-    await expect(program.parseAsync(['import'], { from: 'user' })).rejects.toThrow('process.exit');
+    await expect(program.parseAsync(['import'], { from: 'user' })).rejects.toThrow('process.exit(1)');
 
-    expect(mockRequireTTY).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('requires an interactive terminal'));
     expect(mockRender).not.toHaveBeenCalled();
   });
 
-  it('renders the interactive flow when a TTY is present', async () => {
+  it('exits when only stdin is not a TTY', async () => {
+    process.stdin.isTTY = false;
+    process.stdout.isTTY = true;
+
+    await expect(program.parseAsync(['import'], { from: 'user' })).rejects.toThrow('process.exit(1)');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('renders the interactive flow when both stdin and stdout are TTYs', async () => {
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
+
     await program.parseAsync(['import'], { from: 'user' });
 
-    expect(mockRequireTTY).toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
     expect(mockRender).toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/import/command.ts
+++ b/src/cli/commands/import/command.ts
@@ -25,6 +25,8 @@ export const registerImport = (program: Command) => {
     .action(async (cliOptions: { source?: string; target?: string; yes?: boolean }) => {
       if (!cliOptions.source) {
         // No --source and no subcommand — launch interactive TUI
+        const { requireTTY } = await import('../../tui/guards/tty');
+        requireTTY();
         const { requireProject } = await import('../../tui/guards/project');
         requireProject();
         const { render } = await import('ink');

--- a/src/cli/commands/import/command.ts
+++ b/src/cli/commands/import/command.ts
@@ -24,11 +24,12 @@ export const registerImport = (program: Command) => {
     .option('-y, --yes', 'Auto-confirm prompts')
     .action(async (cliOptions: { source?: string; target?: string; yes?: boolean }) => {
       if (!cliOptions.source) {
-        // No --source and no subcommand — launch interactive TUI
-        const { requireTTY } = await import('../../tui/guards/tty');
-        requireTTY();
-        const { requireProject } = await import('../../tui/guards/project');
+        // No --source and no subcommand — launch interactive TUI.
+        // requireProject() first so users who haven't cd'd to a project get the
+        // more actionable error before the TTY check (consistent with `view`).
+        const { requireProject, requireTTY } = await import('../../tui/guards');
         requireProject();
+        requireTTY();
         const { render } = await import('ink');
         const React = await import('react');
         const { ImportFlow } = await import('../../tui/screens/import');

--- a/src/cli/commands/view/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/view/__tests__/tty-guard.test.ts
@@ -1,0 +1,52 @@
+import { registerView } from '../command';
+import { Command } from '@commander-js/extra-typings';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRequireTTY = vi.fn();
+const mockRequireProject = vi.fn();
+const mockRender = vi.fn();
+
+vi.mock('../../../tui/guards', () => ({
+  requireProject: () => mockRequireProject(),
+  requireTTY: () => mockRequireTTY(),
+}));
+
+vi.mock('ink', () => ({
+  render: (...args: unknown[]) => mockRender(...args),
+}));
+
+vi.mock('../../../tui/screens/recommendation', () => ({ RecommendationHistoryScreen: () => null }));
+vi.mock('../JobDetailScreen', () => ({ JobDetailScreen: () => null }));
+
+describe('view TTY guard', () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    registerView(program);
+    mockRequireTTY.mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('guards the interactive list and never renders in a non-TTY context', async () => {
+    await expect(program.parseAsync(['view', 'recommendation'], { from: 'user' })).rejects.toThrow('process.exit');
+
+    expect(mockRequireTTY).toHaveBeenCalled();
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('guards the interactive detail and never renders in a non-TTY context', async () => {
+    await expect(program.parseAsync(['view', 'recommendation', 'rec-1'], { from: 'user' })).rejects.toThrow(
+      'process.exit'
+    );
+
+    expect(mockRequireTTY).toHaveBeenCalled();
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/view/__tests__/tty-guard.test.ts
+++ b/src/cli/commands/view/__tests__/tty-guard.test.ts
@@ -2,51 +2,105 @@ import { registerView } from '../command';
 import { Command } from '@commander-js/extra-typings';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockRequireTTY = vi.fn();
-const mockRequireProject = vi.fn();
+// Drive the REAL requireTTY by toggling process.stdin.isTTY / process.stdout.isTTY
+// and spying on process.exit / console.error. Only the I/O boundaries are mocked:
+// the Ink renderer and the TUI screens. requireProject is stubbed to a no-op so
+// the TTY guard (which runs after it inside launchTuiList/launchTuiDetail) is what
+// we exercise. All four job types are parameterized so a future refactor that
+// moved the guard into a per-type branch would be caught.
 const mockRender = vi.fn();
 
-vi.mock('../../../tui/guards', () => ({
-  requireProject: () => mockRequireProject(),
-  requireTTY: () => mockRequireTTY(),
-}));
+vi.mock('../../../tui/guards', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../tui/guards')>();
+  return {
+    ...actual,
+    requireProject: vi.fn(),
+  };
+});
 
 vi.mock('ink', () => ({
   render: (...args: unknown[]) => mockRender(...args),
 }));
 
 vi.mock('../../../tui/screens/recommendation', () => ({ RecommendationHistoryScreen: () => null }));
+vi.mock('../../../tui/screens/run-eval', () => ({ BatchEvalHistoryScreen: () => null }));
+vi.mock('../../../tui/screens/run-ab-test', () => ({ ABTestJobsHistoryScreen: () => null }));
+vi.mock('../../../tui/screens/insights-jobs', () => ({ InsightsJobsScreen: () => null }));
 vi.mock('../JobDetailScreen', () => ({ JobDetailScreen: () => null }));
+
+const JOB_TYPES = ['recommendation', 'batch-evaluation', 'ab-test', 'insights'] as const;
 
 describe('view TTY guard', () => {
   let program: Command;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  const origStdinIsTTY = process.stdin.isTTY;
+  const origStdoutIsTTY = process.stdout.isTTY;
 
   beforeEach(() => {
     program = new Command();
     program.exitOverride();
     registerView(program);
-    mockRequireTTY.mockImplementation(() => {
-      throw new Error('process.exit');
+
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+      throw new Error(`process.exit(${code})`);
     });
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
+    process.stdin.isTTY = origStdinIsTTY;
+    process.stdout.isTTY = origStdoutIsTTY;
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
     vi.clearAllMocks();
   });
 
-  it('guards the interactive list and never renders in a non-TTY context', async () => {
-    await expect(program.parseAsync(['view', 'recommendation'], { from: 'user' })).rejects.toThrow('process.exit');
+  describe.each(JOB_TYPES)('view %s', type => {
+    it('guards the interactive list — exits and never renders in a non-TTY context', async () => {
+      process.stdin.isTTY = false;
+      process.stdout.isTTY = false;
 
-    expect(mockRequireTTY).toHaveBeenCalled();
+      await expect(program.parseAsync(['view', type], { from: 'user' })).rejects.toThrow('process.exit(1)');
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('requires an interactive terminal'));
+      expect(mockRender).not.toHaveBeenCalled();
+    });
+
+    it('renders the interactive list when both stdin and stdout are TTYs', async () => {
+      process.stdin.isTTY = true;
+      process.stdout.isTTY = true;
+
+      // launchTuiList resolves a never-settling promise (the TUI owns the event
+      // loop until the user exits), so race the parse against the render rather
+      // than awaiting it.
+      void program.parseAsync(['view', type], { from: 'user' });
+      await vi.waitFor(() => expect(mockRender).toHaveBeenCalled());
+
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('guards the interactive detail — exits and never renders in a non-TTY context', async () => {
+    process.stdin.isTTY = false;
+    process.stdout.isTTY = true;
+
+    await expect(program.parseAsync(['view', 'recommendation', 'rec-1'], { from: 'user' })).rejects.toThrow(
+      'process.exit(1)'
+    );
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
     expect(mockRender).not.toHaveBeenCalled();
   });
 
-  it('guards the interactive detail and never renders in a non-TTY context', async () => {
-    await expect(program.parseAsync(['view', 'recommendation', 'rec-1'], { from: 'user' })).rejects.toThrow(
-      'process.exit'
-    );
+  it('renders the interactive detail when both stdin and stdout are TTYs', async () => {
+    process.stdin.isTTY = true;
+    process.stdout.isTTY = true;
 
-    expect(mockRequireTTY).toHaveBeenCalled();
-    expect(mockRender).not.toHaveBeenCalled();
+    void program.parseAsync(['view', 'recommendation', 'rec-1'], { from: 'user' });
+    await vi.waitFor(() => expect(mockRender).toHaveBeenCalled());
+
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/commands/view/command.tsx
+++ b/src/cli/commands/view/command.tsx
@@ -6,7 +6,7 @@ import { printBatchEvaluationDetail, printBatchEvaluationHistory } from '../../o
 import { printInsightsDetail, printInsightsHistory } from '../../operations/jobs/insights/format';
 import { printRecommendationDetail, printRecommendationHistory } from '../../operations/jobs/recommendation/format';
 import { runCliCommand } from '../../telemetry/cli-command-run';
-import { requireProject } from '../../tui/guards';
+import { requireProject, requireTTY } from '../../tui/guards';
 import type { Command } from '@commander-js/extra-typings';
 
 const TYPE_META: Record<
@@ -95,6 +95,7 @@ function registerViewSubcommand(viewCmd: Command, type: JobType) {
 }
 
 async function launchTuiList(type: JobType): Promise<never> {
+  requireTTY();
   const [{ render }, { default: React }] = await Promise.all([import('ink'), import('react')]);
 
   if (type === 'ab-test') {
@@ -114,6 +115,7 @@ async function launchTuiList(type: JobType): Promise<never> {
 }
 
 async function launchTuiDetail(type: JobType, id: string): Promise<never> {
+  requireTTY();
   const [{ render }, { default: React }] = await Promise.all([import('ink'), import('react')]);
   const { JobDetailScreen } = await import('./JobDetailScreen');
   render(React.createElement(JobDetailScreen, { type, id, onExit: () => process.exit(0) }));

--- a/src/cli/tui/render.ts
+++ b/src/cli/tui/render.ts
@@ -6,6 +6,7 @@ import { type UpdateCheckResult } from '../update-notifier';
 import { App, type InitialRoute } from './App';
 import { clearExitAction, getExitAction } from './exit-action';
 import { clearExitMessage, getExitMessage } from './exit-message';
+import { requireTTY } from './guards/tty';
 import { render } from 'ink';
 import React from 'react';
 
@@ -33,6 +34,10 @@ export interface RenderTUIOptions {
  * This is the entrypoint for all TUI operations.
  */
 export async function renderTUI(options: RenderTUIOptions = {}) {
+  // Centralized interactive-terminal guard for every TUI entrypoint that goes
+  // through renderTUI. Raw `render()` call sites (import, view) guard inline.
+  requireTTY();
+
   const {
     initialRoute,
     updateCheck = Promise.resolve(null),


### PR DESCRIPTION
Refs aws/agentcore-cli#982

## Issues
- **#982** — Running an interactive TUI command in a non-TTY context (piped stdin, CI, backgrounded) crashes with Ink's "Raw mode is not supported on the current process.stdin" stack trace. For `agentcore import` (no --source) the process then exits 0, so CI/scripts cannot detect the failure (the exit-0 variant in the issue). For `agentcore view <type>` and `agentcore export harness` the same launch is unguarded. The literal title reproducer (`agentcore deploy`) is already fixed at v0.20.2, but the underlying bug class persists in import/view/export.

## Root cause
Interactive Ink TUIs render screens whose useInput hook calls setRawMode(true), which throws on non-TTY stdin (ink App.js:117, exact match to the issue text). requireTTY() (src/cli/tui/guards/tty.ts:8-13, added PR #949 / commit c30ed548) guards deploy/create/add/remove/invoke/dev/exec/run/feedback but NOT import/view/export. Verified at v0.20.2: deploy/command.tsx:218,221 are guarded (the original claim that deploy is the gap is wrong); the unguarded interactive launches are import/command.ts:67 (raw render of ImportFlow), view/command.tsx:97-121 (launchTuiList/launchTuiDetail render history screens that use useListNavigation->useInput), export/index.ts:32 (renderTUI export-harness). Import's render() is never awaited via waitUntilExit(), so Ink's ErrorBoundary (App.js:347) swallows the throw and the process exits 0; export awaits renderTUI->waitUntilExit() so its rejection propagates to exit 1 but with the ugly Ink stack trace. index.ts:9-16 only catches uncaughtException/unhandledRejection, neither of which fires for the import no-op rejectExitPromise path.

## The fix
Add requireTTY() before each unguarded interactive launch, mirroring PR #949: import (src/cli/commands/import/command.ts no-source branch before requireProject()/render), view (src/cli/commands/view/command.tsx before launchTuiList/launchTuiDetail), and export (src/cli/commands/export/index.ts before renderTUI at :32). Open PR #1170 is OPEN and "Closes #982" but only patches import/command.ts (7 lines) plus tty/import/deploy tests — its own "Out of scope" section confirms it does NOT cover view or export, so merging it would close the issue while leaving two sites with the identical bug. Recommend expanding #1170 to also guard view and export, or more robustly centralizing the guard: call requireTTY() at the top of renderTUI() (src/cli/tui/render.ts:35) AND at the raw render() interactive sites so any future interactive launch is covered by default.

_Files touched:_ src/cli/commands/import/command.ts:26-29,67-73 (no-source interactive branch; partially addressed by open PR #1170); src/cli/commands/view/command.tsx:97-121 (NOT covered by #1170); src/cli/commands/export/index.ts:32 (NOT covered by #1170); guard def src/cli/tui/guards/tty.ts:8-13; ideal central fix point src/cli/tui/render.ts:35. Deploy already guarded at src/cli/commands/deploy/command.tsx:218,221 (no change needed).

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (rebuilt unpatched HEAD binary at dist/cli/index.mjs, non-TTY via `echo "" | ...`): (1) WORST CASE `agentcore import` (no --source) inside a valid agentcore project rendered the Ink ImportFlow TUI menu and EXITED 0 — failure undetectable to CI/scripts. (2) `agentcore export harness` rendered the TUI and printed the literal "Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default." to stderr. (3) `agentcore view recommendation` and `agentcore view recommendation rec-1` (inside valid project so requireProject passed) rendered the loading TUI screen and EXITED 0. All three unguarded render()/renderTUI() sites were reached, confirming the gap. Verified HEAD has 0 requireTTY calls in import/command.ts, view/command.tsx, export/index.ts.
AFTER (rebuilt fix/982): all four invocations (import in-project, view list, view detail, export harness) exit code 1, print ONLY the plain-text "Error: This command requires an interactive terminal. Use --help to see non-interactive flags." with NO "Raw mode" output and NO exit 0; render()/renderTUI() is never reached. requireTTY() (checks both process.stdin.isTTY and process.stdout.isTTY, console.error + process.exit(1)) is placed before render(ImportFlow) at import/command.ts:29, at the top of launchTuiList (view/command.tsx:98) and launchTuiDetail (:118), and before renderTUI at export/index.ts:33 — matching the proven deploy guard (deploy/command.tsx:222,225, PR #949). 4/4 manual checks passed.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
