### PR TITLE
fix(cli): Add the import-utils.ts:207-213 account-mismatch check to... (#761)

### DIFF
--- a/src/cli/aws/account.ts
+++ b/src/cli/aws/account.ts
@@ -1,4 +1,5 @@
-import { AwsCredentialsError } from '../../lib/errors/types.js';
+import { AwsCredentialsError, ValidationError } from '../../lib/errors/types.js';
+import type { AwsDeploymentTarget } from '../../schema';
 import { getAwsLoginGuidance } from '../external-requirements/checks';
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
 import { fromEnv, fromNodeProviderChain } from '@aws-sdk/credential-providers';
@@ -73,6 +74,22 @@ export async function validateAwsCredentials(): Promise<void> {
         'To fix this:\n' +
         `  1. ${guidance}\n` +
         '  2. Or set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables'
+    );
+  }
+}
+
+/**
+ * Fail fast when the active AWS credentials belong to a different account than the deployment
+ * target. Mirrors the `import` guard (import-utils.ts) so a `deploy` against the wrong account is
+ * caught in preflight instead of surfacing as an opaque CDK assume-role/bootstrap error after
+ * build/synth/publish. Skipped when no account can be detected — the existing no-credentials path
+ * handles that.
+ */
+export async function assertCallerAccountMatchesTarget(target: AwsDeploymentTarget): Promise<void> {
+  const callerAccount = await detectAccount();
+  if (callerAccount && target.account && callerAccount !== target.account) {
+    throw new ValidationError(
+      `Your AWS credentials are for account ${callerAccount}, but the target "${target.name}" is configured for account ${target.account}.\nEnsure your credentials match the deployment target.`
     );
   }
 }

--- a/src/cli/commands/deploy/actions.ts
+++ b/src/cli/commands/deploy/actions.ts
@@ -2,7 +2,7 @@ import { ConfigIO, ResourceNotFoundError, SecureCredentials, ValidationError, to
 import type { Result } from '../../../lib/result';
 import type { AgentCoreMcpSpec, DeployedState } from '../../../schema';
 import { applyTargetRegionToEnv } from '../../aws';
-import { validateAwsCredentials } from '../../aws/account';
+import { assertCallerAccountMatchesTarget, validateAwsCredentials } from '../../aws/account';
 import { CdkToolkitWrapper, createSwitchableIoHost } from '../../cdk/toolkit-lib';
 import type { DeployMessage, SwitchableIoHost } from '../../cdk/toolkit-lib';
 import {
@@ -212,7 +212,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
 
     // Preflight: validate project
     startStep('Validate project');
-    const context = await validateProject();
+    const context = await validateProject(target);
     endStep('success');
 
     // Warn about imperative-build orphan harnesses (preview→GA transition). These aren't
@@ -252,6 +252,7 @@ export async function handleDeploy(options: ValidatedDeployOptions): Promise<Dep
     if (context.isTeardownDeploy) {
       startStep('Validate AWS credentials');
       await validateAwsCredentials();
+      await assertCallerAccountMatchesTarget(target);
       endStep('success');
     }
 

--- a/src/cli/operations/deploy/__tests__/preflight.test.ts
+++ b/src/cli/operations/deploy/__tests__/preflight.test.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from '../../../../lib/errors/types.js';
 import { formatError, validateProject } from '../preflight.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -14,8 +15,9 @@ const { mockValidate } = vi.hoisted(() => ({
   mockValidate: vi.fn(),
 }));
 
-const { mockValidateAwsCredentials } = vi.hoisted(() => ({
+const { mockValidateAwsCredentials, mockDetectAccount } = vi.hoisted(() => ({
   mockValidateAwsCredentials: vi.fn(),
+  mockDetectAccount: vi.fn(),
 }));
 
 const { mockRequireConfigRoot } = vi.hoisted(() => ({
@@ -52,9 +54,23 @@ vi.mock('../../../cdk/local-cdk-project.js', () => ({
   },
 }));
 
-vi.mock('../../../aws/account.js', () => ({
-  validateAwsCredentials: mockValidateAwsCredentials,
-}));
+vi.mock('../../../aws/account.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../aws/account.js')>();
+  return {
+    ...actual,
+    validateAwsCredentials: mockValidateAwsCredentials,
+    detectAccount: mockDetectAccount,
+    // Re-derive the helper from the mocked detectAccount so the test controls the caller account.
+    assertCallerAccountMatchesTarget: async (target: { name: string; account?: string }) => {
+      const callerAccount = await mockDetectAccount();
+      if (callerAccount && target.account && callerAccount !== target.account) {
+        throw new ValidationError(
+          `Your AWS credentials are for account ${callerAccount}, but the target "${target.name}" is configured for account ${target.account}.\nEnsure your credentials match the deployment target.`
+        );
+      }
+    },
+  };
+});
 
 describe('validateProject', () => {
   afterEach(() => vi.clearAllMocks());
@@ -176,6 +192,43 @@ describe('validateProject', () => {
 
     expect(result.projectSpec.name).toBe('test-project');
     expect(result.isTeardownDeploy).toBe(false);
+  });
+
+  it('fails fast when caller account differs from the selected target account', async () => {
+    mockRequireConfigRoot.mockReturnValue('/project/agentcore');
+    mockValidate.mockReturnValue(undefined);
+    mockReadProjectSpec.mockResolvedValue({ name: 'test-project', runtimes: [{ name: 'agent' }] });
+    mockReadAWSDeploymentTargets.mockResolvedValue([]);
+    mockValidateAwsCredentials.mockResolvedValue(undefined);
+    mockDetectAccount.mockResolvedValue('111111111111');
+
+    await expect(
+      validateProject({ name: 'prod', account: '222222222222', region: 'us-east-1' } as never)
+    ).rejects.toThrow(/account 111111111111.*target "prod".*account 222222222222/s);
+  });
+
+  it('does not throw when caller account matches the selected target account', async () => {
+    mockRequireConfigRoot.mockReturnValue('/project/agentcore');
+    mockValidate.mockReturnValue(undefined);
+    mockReadProjectSpec.mockResolvedValue({ name: 'test-project', runtimes: [{ name: 'agent' }] });
+    mockReadAWSDeploymentTargets.mockResolvedValue([]);
+    mockValidateAwsCredentials.mockResolvedValue(undefined);
+    mockDetectAccount.mockResolvedValue('222222222222');
+
+    const result = await validateProject({ name: 'prod', account: '222222222222', region: 'us-east-1' } as never);
+    expect(result.projectSpec.name).toBe('test-project');
+  });
+
+  it('skips the account comparison when detectAccount returns null', async () => {
+    mockRequireConfigRoot.mockReturnValue('/project/agentcore');
+    mockValidate.mockReturnValue(undefined);
+    mockReadProjectSpec.mockResolvedValue({ name: 'test-project', runtimes: [{ name: 'agent' }] });
+    mockReadAWSDeploymentTargets.mockResolvedValue([]);
+    mockValidateAwsCredentials.mockResolvedValue(undefined);
+    mockDetectAccount.mockResolvedValue(null);
+
+    const result = await validateProject({ name: 'prod', account: '222222222222', region: 'us-east-1' } as never);
+    expect(result.projectSpec.name).toBe('test-project');
   });
 
   it('accepts gateway target name within 48 chars when prefixed with project name', async () => {

--- a/src/cli/operations/deploy/preflight.ts
+++ b/src/cli/operations/deploy/preflight.ts
@@ -1,7 +1,7 @@
 import { ConfigIO, DOCKERFILE_NAME, getDockerfilePath, requireConfigRoot, resolveCodeLocation } from '../../../lib';
 import { ValidationError } from '../../../lib/errors/types';
 import type { AgentCoreProjectSpec, AwsDeploymentTarget } from '../../../schema';
-import { validateAwsCredentials } from '../../aws/account';
+import { assertCallerAccountMatchesTarget, validateAwsCredentials } from '../../aws/account';
 import { LocalCdkProject } from '../../cdk/local-cdk-project';
 import { CdkToolkitWrapper, createCdkToolkitWrapper, silentIoHost } from '../../cdk/toolkit-lib';
 import { checkBootstrapStatus, checkStacksStatus, formatCdkEnvironment } from '../../cloudformation';
@@ -65,7 +65,7 @@ export function formatError(err: unknown): string {
  */
 const MAX_RUNTIME_NAME_LENGTH = 48;
 
-export async function validateProject(): Promise<PreflightContext> {
+export async function validateProject(selectedTarget?: AwsDeploymentTarget): Promise<PreflightContext> {
   // Find the agentcore config directory, walking up from cwd if needed
   const configRoot = requireConfigRoot();
   // Project root is the parent of the agentcore directory
@@ -143,6 +143,13 @@ export async function validateProject(): Promise<PreflightContext> {
   // Skip for teardown deploys — callers validate after teardown confirmation.
   if (!isTeardownDeploy) {
     await validateAwsCredentials();
+    // Fail fast on an account mismatch so a wrong-account deploy is caught here instead of as an
+    // opaque CDK assume-role/bootstrap error after build/synth/publish. The headless CLI passes the
+    // resolved target; the TUI deploys the first target, so fall back to it.
+    const target = selectedTarget ?? awsTargets[0];
+    if (target) {
+      await assertCallerAccountMatchesTarget(target);
+    }
   }
 
   return { projectSpec, awsTargets, cdkProject, isTeardownDeploy, isFirstDeploy: !hasExistingStack };

--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -2,7 +2,7 @@ import { ConfigIO, SecureCredentials, toError } from '../../../lib';
 import { AwsCredentialsError, UserCancellationError } from '../../../lib/errors/types';
 import type { DeployedState } from '../../../schema';
 import { applyTargetRegionToEnv } from '../../aws';
-import { validateAwsCredentials } from '../../aws/account';
+import { assertCallerAccountMatchesTarget, validateAwsCredentials } from '../../aws/account';
 import { type CdkToolkitWrapper, type SwitchableIoHost, createSwitchableIoHost } from '../../cdk/toolkit-lib';
 import { getErrorMessage, isExpiredTokenError, isNoCredentialsError } from '../../errors';
 import type { ExecLogger } from '../../logging';
@@ -442,6 +442,10 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
         if (preflightContext.isTeardownDeploy) {
           try {
             await validateAwsCredentials();
+            const teardownTarget = preflightContext.awsTargets[0];
+            if (teardownTarget) {
+              await assertCallerAccountMatchesTarget(teardownTarget);
+            }
           } catch (err) {
             const errorMsg = formatError(err);
             logger.endStep('error', errorMsg);


### PR DESCRIPTION
Refs aws/agentcore-cli#761

## Issues
- **#761** — Running `agentcore deploy` with valid AWS credentials for an account different from the one in aws-targets.json proceeds through load-target, validate, dependency, build, synth, and stack-status steps and only fails at the publish-assets/deploy step with a generic CDK error. The user gets no clear, early "your credentials are for account X but the target is account Y" message even though the CLI already has exactly that check for `import`.

## Root cause
Deploy preflight validateAwsCredentials() (preflight.ts:143 -> account.ts:66-78) only null-checks detectAccount() and never compares caller account to target.account; the mismatch surfaces only when the CDK toolkit publishes assets/assumes roles into aws://{target.account}/{region} (bootstrap.ts:45 used at preflight.ts:333; wrapper.ts:246-256). The guard exists only for import (import-utils.ts:207-213), never ported to deploy.

## The fix
Add the import-utils.ts:207-213 account-mismatch check to deploy preflight. Cleanest approach: thread the selected target/account into validateProject() and, after the validateAwsCredentials() call (preflight.ts:143), call detectAccount() and throw a ValidationError when callerAccount !== target.account (reuse the import-utils message and the existing detectAccount() helper — no new design beyond choosing how to pass the resolved target into validateProject). Because both the headless CLI path (commands/deploy/actions.ts handleDeploy) and the TUI path (tui/hooks/useCdkPreflight.ts) route through validateProject(), centralizing it there covers both; also cover the teardown-deferred credential branches (actions.ts:222-226 and useCdkPreflight.ts:442-457) so teardown deploys get the same check after confirmation. Skip the comparison only when detectAccount() returns null (let the existing no-credentials path handle that).

_Files touched:_ src/cli/operations/deploy/preflight.ts (validateProject, add account compare after validateAwsCredentials at ~line 143 — requires threading the selected target into validateProject); src/cli/commands/deploy/actions.ts (target resolved ~line 158; teardown-deferred creds check ~lines 222-226); src/cli/tui/hooks/useCdkPreflight.ts (teardown-deferred creds branch ~lines 442-457); reuse the exact pattern + message from src/cli/commands/import/import-utils.ts:207-213; helpers detectAccount()/validateAwsCredentials() in src/cli/aws/account.ts:22-78

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (symptom reproduced): Reverted only production code (src/cli/operations/deploy/preflight.ts + src/cli/aws/account.ts) to original HEAD while keeping the fix's test file, then ran preflight.test.ts. The 'fails fast when caller account differs from the selected target account' test FAILED: 'AssertionError: promise resolved "{ projectSpec: ... }" instead of rejecting'. This proves the original validateProject() (no-arg signature at preflight.ts:68, only validateAwsCredentials() at line 145) completed preflight successfully on an account mismatch and would have proceeded to build/synth/publish, then failed late with an opaque CDK assume-role/bootstrap error -- exactly the wasted-workflow symptom. AFTER (symptom gone): Restored fixed code. preflight.test.ts 16/16 pass. Real wiring verified: preflight.ts:149-151 resolves selectedTarget ?? awsTargets[0] and calls the real assertCallerAccountMatchesTarget (account.ts:88-95), whose message is byte-identical to import-utils.ts:207-213. Teardown branches guarded at actions.ts:253 and useCdkPreflight.ts:445-448. Adversarial extra: a throwaway test exercising the REAL helper with only the AWS SDK mocked (real detectAccount) confirmed it throws ValidationError naming both accounts (caller 111111111111 vs target "prod"/222222222222) on mismatch, resolves on equal accounts, and skips when detectAccount returns null; removed afterward to keep the diff surgical. Full unit suite green: 377 files / 5454 tests passing.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
