### PR TITLE
fix(cli): Change command.tsx:213 from `result.targetName ?? 'No tar... (#985)

### DIFF
--- a/src/cli/commands/status/command.tsx
+++ b/src/cli/commands/status/command.tsx
@@ -209,7 +209,8 @@ export const registerStatus = (program: Command) => {
         render(
           <Box flexDirection="column">
             <Text bold>
-              AgentCore Status (target: {result.targetName ?? 'No target configured'}
+              AgentCore Status (target:{' '}
+              {result.targetName && result.targetName.length > 0 ? result.targetName : 'No target configured'}
               {result.targetRegion ? `, ${result.targetRegion}` : ''})
             </Text>
 


### PR DESCRIPTION
Refs aws/agentcore-cli#985

## Issues
- **#985** — On a freshly created project with no deployment target configured, `agentcore status` prints a broken header `AgentCore Status (target: )` with an empty value inside the parens, instead of omitting the label or showing a sensible default like "No target configured". Cosmetic, but it looks like a rendering glitch on the very first command a new user runs after `agentcore create`.

## Root cause
Empty-string vs nullish mismatch at command.tsx:213; verified bug is live at HEAD v0.20.2.

## The fix
Change command.tsx:213 from `result.targetName ?? 'No target configured'` back to `result.targetName || 'No target configured'` (or the explicit `targetName && targetName.length > 0 ? ... : 'No target configured'` ternary). CRITICAL: the open PR #1171 does NOT fix this issue as written — I read its diff via `gh pr diff 1171`. It only changes command.tsx line ~141, the `--runtime-id` lookup path (`AgentCore Status - {runtimeId} (target: ...)`), and adds an action.ts unit test asserting targetName===''. But the #985 reproducer runs `agentcore status` with NO --runtime-id, hitting the DEFAULT path (line 213), which PR #1171 leaves untouched at `?? 'No target configured'`. Worse, the --runtime-id path #1171 does fix is unreachable by the reproducer (a fresh `create` has no deployed runtime to look up). PR #1171 must be extended to also fix line 213, or it will close #985 without fixing the reported behavior.

_Files touched:_ src/cli/commands/status/command.tsx:213 (default-path header render — the line the issue reproducer actually hits). Supporting: src/cli/commands/status/action.ts:702 returns `targetName: selectedTargetName ?? ''` for the no-target case; src/cli/commands/create/action.ts:96 writes empty aws-targets so the no-target case is the default on a fresh project. command.tsx:141 is the only render line PR #1171 currently touches and is the latent --runtime-id-path twin of the same bug.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> Reproduced the original symptom on the pre-fix render layer and watched it disappear with the fix, exercising the actual default-path header output (not a unit-only test).

BEFORE (stashed the fix, rebuilt with command.tsx:212 = `result.targetName ?? 'No target configured'`): In a freshly created project (/tmp/acfix-985.iw6Ypv/acfix985, aws-targets.json = `[]`, no deployment), `agentcore status` (no --runtime-id) rendered header line: `AgentCore Status (target: )` — empty parens. grep `target: )` matched -> EMPTY PARENS REPRODUCED. Mechanism confirmed: action.ts:697 returns `targetName: selectedTargetName ?? ''` (empty string for no-target), and `??` does not catch '' so it prints verbatim.

AFTER (fix restored at command.tsx:212-213 = `result.targetName && result.targetName.length > 0 ? result.targetName : 'No target configured'`, rebuilt): Same command in the same fresh project rendered exactly `AgentCore Status (target: No target configured)`. grep for `target: )` -> no match (FIXED). JSON path unchanged: `agentcore status --json` still emits `"targetName": ""`, confirming the fix is render-layer-only and surgical (action.ts behavior untouched). Mirrors the PR #1171 length-check pattern already on the --runtime-id twin at command.tsx:140.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
