### PR TITLE
fix(unit-only): Add `dockerfileBaseDir?: string` to AddHarnessOptions; re... (#1128)

### DIFF
--- a/src/cli/commands/create/command.tsx
+++ b/src/cli/commands/create/command.tsx
@@ -156,7 +156,10 @@ function printCreateHarnessSummary(projectName: string, harnessName: string): vo
 
 /** Handle CLI mode for the harness path */
 async function handleCreateHarnessCLI(options: CreateOptions): Promise<void> {
-  const cwd = options.outputDir ?? getWorkingDirectory();
+  // The invocation cwd is where the user typed a relative --container Dockerfile path. Capture it
+  // before --output-dir overrides `cwd`, so the Dockerfile resolves from where the command was run.
+  const invocationCwd = getWorkingDirectory();
+  const cwd = options.outputDir ?? invocationCwd;
   const name = options.name ?? options.projectName;
   const projectName = options.projectName ?? name;
 
@@ -274,6 +277,7 @@ async function handleCreateHarnessCLI(options: CreateOptions): Promise<void> {
         additionalParams,
         containerUri: containerOption.containerUri,
         dockerfilePath: containerOption.dockerfilePath,
+        dockerfileBaseDir: invocationCwd,
         skipMemory: options.harnessMemory === false,
         maxIterations: options.maxIterations ? Number(options.maxIterations) : undefined,
         maxTokens: options.maxTokens ? Number(options.maxTokens) : undefined,

--- a/src/cli/commands/create/harness-action.ts
+++ b/src/cli/commands/create/harness-action.ts
@@ -19,6 +19,8 @@ export interface CreateHarnessProjectOptions {
   skipMemory?: boolean;
   containerUri?: string;
   dockerfilePath?: string;
+  /** Base dir a relative dockerfilePath resolves against (the invocation cwd). Defaults to `cwd`. */
+  dockerfileBaseDir?: string;
   maxIterations?: number;
   maxTokens?: number;
   timeoutSeconds?: number;
@@ -68,6 +70,7 @@ export async function createProjectWithHarness(options: CreateHarnessProjectOpti
       additionalParams: options.additionalParams,
       containerUri: options.containerUri,
       dockerfilePath: options.dockerfilePath,
+      dockerfileBaseDir: options.dockerfileBaseDir ?? cwd,
       skipMemory: options.skipMemory,
       maxIterations: options.maxIterations,
       maxTokens: options.maxTokens,

--- a/src/cli/primitives/HarnessPrimitive.ts
+++ b/src/cli/primitives/HarnessPrimitive.ts
@@ -132,6 +132,13 @@ export interface AddHarnessOptions {
   memoryRelevanceScore?: number;
   containerUri?: string;
   dockerfilePath?: string;
+  /**
+   * Base directory a relative dockerfilePath is resolved against. During `create` this is the
+   * invocation cwd (where the user typed the relative path), since configBaseDir points at the
+   * freshly-created project subdir. Defaults to projectRoot (dirname(configBaseDir)) when omitted,
+   * preserving standalone `add harness`.
+   */
+  dockerfileBaseDir?: string;
   maxIterations?: number;
   maxTokens?: number;
   timeoutSeconds?: number;
@@ -222,9 +229,10 @@ export class HarnessPrimitive extends BasePrimitive<AddHarnessOptions, Removable
       let dockerfile: string | undefined;
       if (options.dockerfilePath) {
         const projectRoot = dirname(configBaseDir);
+        const dockerfileBaseDir = options.dockerfileBaseDir ?? projectRoot;
         const srcPath = isAbsolute(options.dockerfilePath)
           ? options.dockerfilePath
-          : resolve(projectRoot, options.dockerfilePath);
+          : resolve(dockerfileBaseDir, options.dockerfilePath);
         try {
           await access(srcPath);
         } catch {

--- a/src/cli/primitives/__tests__/HarnessPrimitive.add.dockerfile.test.ts
+++ b/src/cli/primitives/__tests__/HarnessPrimitive.add.dockerfile.test.ts
@@ -1,0 +1,86 @@
+import { HarnessPrimitive } from '../HarnessPrimitive';
+import { access, copyFile } from 'fs/promises';
+import { join, resolve } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Relative Dockerfile resolution during `create`: configBaseDir points at the freshly-created
+// project subdir (cwd/<projectName>/agentcore), so a relative --container path must resolve against
+// the INVOCATION cwd (passed as dockerfileBaseDir), not dirname(configBaseDir). Without
+// dockerfileBaseDir, resolution falls back to projectRoot so standalone `add harness` is unchanged.
+
+const mockReadProjectSpec = vi.fn();
+
+vi.mock('../../../lib', () => ({
+  APP_DIR: 'app',
+  ConfigIO: class {
+    readProjectSpec = mockReadProjectSpec;
+    writeProjectSpec = vi.fn();
+    writeHarnessSpec = vi.fn();
+    getPathResolver = () => ({ getHarnessDir: (name: string) => `/invocation/cwd/proj/agentcore/app/${name}` });
+  },
+  findConfigRoot: () => '/invocation/cwd/proj/agentcore',
+}));
+
+vi.mock('fs/promises', () => ({
+  access: vi.fn(),
+  copyFile: vi.fn(),
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+const INVOCATION_CWD = '/invocation/cwd';
+const CONFIG_BASE_DIR = '/invocation/cwd/proj/agentcore';
+
+function baseProject() {
+  return { name: 'proj', harnesses: [], memories: [], runtimes: [] };
+}
+
+/** access() succeeds only for the Dockerfile sitting at the invocation cwd, and nowhere else. */
+function onlyExistsAtInvocationCwd() {
+  vi.mocked(access).mockImplementation(async (p: Parameters<typeof access>[0]) => {
+    if (String(p) === resolve(INVOCATION_CWD, './Dockerfile')) return;
+    throw new Error('ENOENT');
+  });
+}
+
+describe('HarnessPrimitive.add — relative Dockerfile base dir', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('resolves a relative dockerfilePath against dockerfileBaseDir (invocation cwd), not projectRoot', async () => {
+    mockReadProjectSpec.mockResolvedValue(baseProject());
+    onlyExistsAtInvocationCwd();
+
+    const result = await new HarnessPrimitive().add({
+      name: 'support',
+      modelProvider: 'bedrock',
+      modelId: 'anthropic.claude-3',
+      configBaseDir: CONFIG_BASE_DIR,
+      dockerfilePath: './Dockerfile',
+      dockerfileBaseDir: INVOCATION_CWD,
+    } as never);
+
+    expect(result.success).toBe(true);
+    const [src, dest] = vi.mocked(copyFile).mock.calls.at(-1)!;
+    expect(src).toBe(resolve(INVOCATION_CWD, './Dockerfile'));
+    // Destination still lands under the project: agentcore/app/<name>/Dockerfile.
+    expect(dest).toBe(join('/invocation/cwd/proj', 'app', 'support', 'Dockerfile'));
+  });
+
+  it('falls back to projectRoot when dockerfileBaseDir is omitted (standalone add harness unchanged)', async () => {
+    mockReadProjectSpec.mockResolvedValue(baseProject());
+    onlyExistsAtInvocationCwd();
+
+    const result = await new HarnessPrimitive().add({
+      name: 'support',
+      modelProvider: 'bedrock',
+      modelId: 'anthropic.claude-3',
+      configBaseDir: CONFIG_BASE_DIR,
+      dockerfilePath: './Dockerfile',
+    } as never);
+
+    expect(result.success).toBe(false);
+    expect((result as { error: Error }).error.name).toBe('ResourceNotFoundError');
+    expect((result as { error: Error }).error.message).toContain('Dockerfile not found at');
+  });
+});

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -636,6 +636,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
                 ...memoryOptions,
                 containerUri: addHarnessConfig.containerUri,
                 dockerfilePath: addHarnessConfig.dockerfilePath,
+                dockerfileBaseDir: cwd,
                 maxIterations: addHarnessConfig.maxIterations,
                 maxTokens: addHarnessConfig.maxTokens,
                 timeoutSeconds: addHarnessConfig.timeoutSeconds,


### PR DESCRIPTION
Refs aws/agentcore-cli#1128

## Issues
- **#1128** — In the preview `agentcore create` harness flow, when a user supplies a RELATIVE Dockerfile path (e.g. `./Dockerfile` or via `--container ./Dockerfile`), the CLI resolves it against the freshly-created project directory (cwd/<projectName>) instead of the directory where they ran `agentcore create`. The user gets a hard `Dockerfile not found at: <wrong-path>` error even though the file exists where they typed it relative to. Confined to relative paths in the create flow; absolute paths work, and standalone `add harness` is unaffected (its project root equals the invocation context).

## Root cause
In src/cli/primitives/HarnessPrimitive.ts:243-246 the relative dockerfilePath is resolved against projectRoot = dirname(configBaseDir); during create, configBaseDir is the newly-minted cwd/<projectName>/agentcore (harness-action.ts:55-56, useCreateFlow.ts:296-297), so resolution happens from cwd/<projectName> instead of the invocation cwd. Verified by reading all four files at HEAD; dockerfileBaseDir does not exist in src.

## The fix
Add `dockerfileBaseDir?: string` to AddHarnessOptions; resolve relative Dockerfile paths against `options.dockerfileBaseDir ?? projectRoot` (HarnessPrimitive.ts:246); pass the invocation cwd as dockerfileBaseDir from the CLI create path (command.tsx, capturing getWorkingDirectory() before the outputDir override), from createProjectWithHarness (default `?? cwd`), and from the TUI path (useCreateFlow.ts, `dockerfileBaseDir: cwd`). Keeping projectRoot as fallback preserves standalone `add harness`. Absolute paths still bypass via isAbsolute(). This is exactly open PR #1474 — merge it.

_Files touched:_ src/cli/primitives/HarnessPrimitive.ts (AddHarnessOptions interface + the relative-path resolve at lines 242-246), src/cli/commands/create/command.tsx (handleCreateHarnessCLI ~lines 142, 204), src/cli/commands/create/harness-action.ts (CreateHarnessProjectOptions ~line 21 + the add() call ~line 70), src/cli/tui/screens/create/useCreateFlow.ts (~line 657 harness add). All in the agentcore-cli repo. Fix already authored in OPEN PR #1474 (branch fix-create-harness-dockerfile-base).

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (fix reverted in HarnessPrimitive.ts to `resolve(projectRoot, dockerfilePath)`): the regression test fails reproducing the exact original symptom — a relative dockerfilePath ('./Dockerfile') resolves against projectRoot (/invocation/cwd/proj, the freshly-created project subdir) instead of the invocation cwd; access() throws ENOENT; HarnessPrimitive.add() returns success:false with ResourceNotFoundError 'Dockerfile not found at: /invocation/cwd/proj/Dockerfile'. Vitest: 'expected false to be true' at result.success.

AFTER (fix applied: `const dockerfileBaseDir = options.dockerfileBaseDir ?? projectRoot; resolve(dockerfileBaseDir, dockerfilePath)`): same test passes — relative path resolves against dockerfileBaseDir=INVOCATION_CWD, add() returns success:true, copyFile src=resolve('/invocation/cwd','./Dockerfile'), dest=/invocation/cwd/proj/app/support/Dockerfile (lands under agentcore/app/<name>/). Fallback test (dockerfileBaseDir omitted) still returns ResourceNotFoundError 'Dockerfile not found at' so standalone `add harness` is unchanged. Absolute paths bypass via isAbsolute() (untouched branch). New test file: 2/2 pass with fix, 1/2 fails (reproduces symptom) without fix.

Plumbing verified: command.tsx captures invocationCwd=getWorkingDirectory() BEFORE --output-dir overrides cwd and passes dockerfileBaseDir=invocationCwd; harness-action.ts defaults dockerfileBaseDir to cwd; useCreateFlow.ts passes cwd. configBaseDir=join(projectRoot,CONFIG_DIR) confirmed to point 

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
