### PR TITLE
fix(cli): Add useCreateFlow.goBackToInput() (setPhase('input')) and... (#602)

### DIFF
--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -274,6 +274,16 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
     onExit,
   ]);
 
+  // Esc on the create-type prompt returns to the project-name input (matching the
+  // "Esc back" footer); on every other phase it falls through to the top-level exit.
+  const handleBack = useCallback(() => {
+    if (flow.phase === 'create-type-prompt') {
+      flow.goBackToInput();
+    } else {
+      handleExit();
+    }
+  }, [flow, handleExit]);
+
   // Auto-exit when project creation completes successfully
   useEffect(() => {
     if (allSuccess) {
@@ -287,7 +297,7 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
     onSelect: item => {
       flow.handleCreateTypeSelection(item.id as 'harness' | 'agent' | 'skip');
     },
-    onExit: handleExit,
+    onExit: handleBack,
     isActive: flow.phase === 'create-type-prompt',
   });
 
@@ -342,7 +352,7 @@ export function CreateScreen({ cwd, isInteractive, onExit, onNavigate }: CreateS
             : undefined;
 
   return (
-    <Screen title="AgentCore Create" onExit={handleExit} headerContent={headerContent} helpText={helpText}>
+    <Screen title="AgentCore Create" onExit={handleBack} headerContent={headerContent} helpText={helpText}>
       {phase === 'existing-project-error' && (
         <Box marginBottom={1} flexDirection="column">
           <Text color="red">A project already exists at this location.</Text>

--- a/src/cli/tui/screens/create/__tests__/CreateScreen.test.tsx
+++ b/src/cli/tui/screens/create/__tests__/CreateScreen.test.tsx
@@ -1,0 +1,39 @@
+import { CreateScreen } from '../CreateScreen.js';
+import { render } from 'ink-testing-library';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const ENTER = '\r';
+const ESCAPE = '\x1B';
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 20));
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('CreateScreen Esc on create-type prompt', () => {
+  it('returns to the project-name input without exiting the CLI', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'create-screen-'));
+    const onExit = vi.fn();
+    const { stdin, lastFrame } = render(<CreateScreen cwd={cwd} isInteractive onExit={onExit} />);
+
+    // Wait for the existing-project check to resolve into the input phase.
+    await tick();
+    expect(lastFrame()).toContain('Create a new AgentCore project');
+
+    // Submit a valid project name -> advances to the create-type prompt.
+    stdin.write('MyProject');
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    expect(lastFrame()).toContain('What would you like to build?');
+
+    // Esc must go back to the name input, not quit the CLI.
+    stdin.write(ESCAPE);
+    await tick();
+    expect(lastFrame()).toContain('Create a new AgentCore project');
+    expect(onExit).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/tui/screens/create/useCreateFlow.ts
+++ b/src/cli/tui/screens/create/useCreateFlow.ts
@@ -73,6 +73,7 @@ interface CreateFlowState {
   // Project name actions
   setProjectName: (name: string) => void;
   confirmProjectName: () => void;
+  goBackToInput: () => void;
   // Create type selection
   handleCreateTypeSelection: (choice: 'harness' | 'agent' | 'skip') => void;
   // Add agent config (set when AddAgentScreen completes)
@@ -178,6 +179,10 @@ export function useCreateFlow(cwd: string): CreateFlowState {
 
   const confirmProjectName = useCallback(() => {
     setPhase('create-type-prompt');
+  }, []);
+
+  const goBackToInput = useCallback(() => {
+    setPhase('input');
   }, []);
 
   const updateStep = (index: number, update: Partial<Step>) => {
@@ -756,6 +761,7 @@ export function useCreateFlow(cwd: string): CreateFlowState {
     logFilePath,
     setProjectName,
     confirmProjectName,
+    goBackToInput,
     // Create type selection
     handleCreateTypeSelection,
     // Add agent


### PR DESCRIPTION
Refs aws/agentcore-cli#602

## Issues
- **#602** — On the screen reached after typing a project name in interactive `agentcore create` (the "Would you like to add an agent now?" create-prompt in GA, or "What would you like to build?" create-type-prompt in preview), the footer says "Esc back" but pressing Esc quits the whole CLI and discards the in-progress create. No back navigation to the name input is possible. No data loss (nothing is written before this point) and the user can simply rerun `agentcore create`, so impact is a confusing UX papercut, not a functional failure.

## Root cause
Verified at v0.20.2 (commit e92c79a4) by reading every link in the chain myself. Esc on the create-prompt/create-type-prompt phase quits the CLI instead of going back: useListNavigation.ts:111-114 fires onExit on Esc; CreateScreen.tsx:297,307 set that onExit=handleExit; handleExit (CreateScreen.tsx:265-282) calls props.onExit when not in success; App.tsx:305-308 wires onExit=handleBack which (App.tsx:111-117) calls exit() because command.tsx:42-49 sets actionOnBack:'exit'. The footer for these phases is NAVIGATE_SELECT "...Esc back..." (constants.ts:16, CreateScreen.tsx:355). useCreateFlow has no create-prompt→input back handler (confirmProjectName useCreateFlow.ts:186-188 only moves forward; goBackFromAddAgent at 222-224 only goes wizard→create-prompt), so Esc falls through to exit, contradicting the footer.

## The fix
Add a goBackToInput action to useCreateFlow (e.g. const goBackToInput = useCallback(() => setPhase('input'), []); expose it on CreateFlowState) and use it as the onExit for the two useListNavigation hooks driving the create-prompt and create-type-prompt phases in CreateScreen.tsx, replacing handleExit. Esc then returns to the project-name input, matching the "Esc back" footer and the user's stated expectation, consistent with the wizard layer's existing Esc-back behavior. The name input's own Esc (TextInput onCancel={handleExit}, CreateScreen.tsx:390) then becomes the single top-level cancel point, which is correct. Lower-quality alternative: relabel only these phases' footer to an "Esc cancel" constant, but going-back is the expected UX given every other list screen treats Esc as back. Pure CLI TUI wiring — no SDK/CDK/service involvement.

_Files touched:_ src/cli/tui/screens/create/CreateScreen.tsx — the two useListNavigation onExit handlers for create-prompt (line 297) and create-type-prompt (line 307), change onExit from handleExit to the new goBackToInput. src/cli/tui/screens/create/useCreateFlow.ts — add goBackToInput = useCallback(() => setPhase('input'), []) near confirmProjectName (~line 186-188), declare it on the CreateFlowState interface (~line 74-76), and return it in the hook's return object (~line 776-792).

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (unfixed source restored via git stash, provided unit test run): test FAILED. After submitting project name 'MyProject' and pressing Esc on the create-type-prompt, lastFrame() still rendered "What would you like to build?" with footer "↑↓ navigate · Enter select · Esc back · Ctrl+C quit" — the screen never returned to the "Create a new AgentCore project" input phase. Confirmed unfixed CreateScreen.tsx:290 wires create-type-prompt useListNavigation onExit=handleExit (top-level exit) with no back handler; no goBackToInput/handleBack present. This is the exact reported symptom (Esc on build-type select does not go back to name input). AFTER (fix in working tree): same test PASSES 1/1 — Esc returns to phase 'input' ("Create a new AgentCore project" reappears) and onExit mock is NOT called. Fix adds useCreateFlow.goBackToInput() (setPhase('input')) and a CreateScreen handleBack callback that calls flow.goBackToInput() only when phase==='create-type-prompt' else handleExit; both the create-type useListNavigation onExit and Screen onExit are rewired to handleBack. Adversarial temp tests (since removed) also confirmed: (1) Esc on the name input itself still fires top-level onExit (single cancel point preserved); (2) Esc-back then Esc-again cancels via onExit. Both passed.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
