### PR TITLE
fix(unit-only): Add aws-opentelemetry-distro to the MCP standalone pyproj... (#683)

### DIFF
--- a/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
+++ b/src/assets/__tests__/__snapshots__/assets.snapshot.test.ts.snap
@@ -6903,6 +6903,7 @@ description = "AgentCore MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "aws-opentelemetry-distro",
     "mcp >= 1.19.0",
 ]
 

--- a/src/assets/python/mcp/standalone/base/pyproject.toml
+++ b/src/assets/python/mcp/standalone/base/pyproject.toml
@@ -9,6 +9,7 @@ description = "AgentCore MCP Server"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "aws-opentelemetry-distro",
     "mcp >= 1.19.0",
 ]
 

--- a/src/cli/commands/import/actions.ts
+++ b/src/cli/commands/import/actions.ts
@@ -43,7 +43,7 @@ function toAgentEnvSpec(agent: ParsedStarterToolkitConfig['agents'][0]): AgentEn
     runtimeVersion: (agent.runtimeVersion ?? 'PYTHON_3_12') as any,
     protocol: agent.protocol,
     networkMode: agent.networkMode,
-    instrumentation: { enableOtel: agent.protocol === 'MCP' ? false : agent.enableOtel },
+    instrumentation: { enableOtel: agent.enableOtel },
   };
   /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any */
 

--- a/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
+++ b/src/cli/operations/agent/generate/__tests__/schema-mapper.test.ts
@@ -192,6 +192,16 @@ describe('mapGenerateConfigToRenderConfig', () => {
     const result = await mapGenerateConfigToRenderConfig(config, []);
     expect(result.memoryProviders[0]!.strategies).toEqual(['SEMANTIC', 'USER_PREFERENCE', 'SUMMARIZATION', 'EPISODIC']);
   });
+
+  it('enables OTel for MCP Python and disables it for MCP TypeScript', async () => {
+    const python = await mapGenerateConfigToRenderConfig({ ...baseConfig, protocol: 'MCP', language: 'Python' }, []);
+    const typescript = await mapGenerateConfigToRenderConfig(
+      { ...baseConfig, protocol: 'MCP', language: 'TypeScript' },
+      []
+    );
+    expect(python.enableOtel).toBe(true);
+    expect(typescript.enableOtel).toBe(false);
+  });
 });
 
 describe('mapGenerateConfigToAgent protocol mode', () => {
@@ -203,6 +213,16 @@ describe('mapGenerateConfigToAgent protocol mode', () => {
     const result = mapGenerateConfigToAgent(mcpConfig);
     expect(result.protocol).toBe('MCP');
     expect(result).not.toHaveProperty('modelProvider');
+  });
+
+  it('does not force OTel off for MCP Python (schema default enables it)', () => {
+    const result = mapGenerateConfigToAgent({ ...baseConfig, protocol: 'MCP', language: 'Python' });
+    expect(result).not.toHaveProperty('instrumentation');
+  });
+
+  it('keeps OTel off for MCP TypeScript', () => {
+    const result = mapGenerateConfigToAgent({ ...baseConfig, protocol: 'MCP', language: 'TypeScript' });
+    expect(result.instrumentation).toEqual({ enableOtel: false });
   });
 
   it('sets protocol to HTTP explicitly', () => {

--- a/src/cli/operations/agent/generate/schema-mapper.ts
+++ b/src/cli/operations/agent/generate/schema-mapper.ts
@@ -156,7 +156,7 @@ export function mapGenerateConfigToAgent(config: GenerateConfig): AgentEnvSpec {
         }
       : {}),
     ...buildFilesystemConfigurations(config.sessionStorageMountPath, config.efsAccessPoints, config.s3AccessPoints),
-    ...(protocol === 'MCP' && { instrumentation: { enableOtel: false } }),
+    ...(protocol === 'MCP' && config.language === 'TypeScript' && { instrumentation: { enableOtel: false } }),
   };
 }
 
@@ -269,7 +269,7 @@ export async function mapGenerateConfigToRenderConfig(
 ): Promise<AgentRenderConfig> {
   const isMcp = config.protocol === 'MCP';
   const gatewayProviders = isMcp ? [] : await mapGatewaysToGatewayProviders();
-  const enableOtel = !isMcp && config.language !== 'TypeScript';
+  const enableOtel = config.language !== 'TypeScript';
 
   return {
     name: config.projectName,


### PR DESCRIPTION
Refs aws/agentcore-cli#683

## Issues
- **#683** — Agents deployed as MCP runtimes get no ADOT/OpenTelemetry tracing by default, while regular (HTTP) Python agents are instrumented automatically. Users running MCP servers silently miss runtime-level observability (no spans in the backend) until they manually flip the setting and add the missing dependency, so the two runtime types behave inconsistently.

## Root cause
The CLI explicitly writes instrumentation.enableOtel=false for MCP on all authoring paths (schema-mapper.ts:159, schema-mapper.ts:272, import/actions.ts:46), defeating the CDK construct's `?? true` default at AgentCoreRuntime.ts:156-157 (verified at pinned ^alpha.19 and at alpha.39). The Zod schema default of true (agent-env.ts:106, mcp.ts:273) never applies because of the explicit false — so the 'already-fixed by defaults' reasoning is incorrect. The MCP standalone pyproject template (src/assets/python/mcp/standalone/base/pyproject.toml:11-13) also omits the otel distro that HTTP templates ship, so the two changes are genuinely coupled.

## The fix
Add aws-opentelemetry-distro to the MCP standalone pyproject template AND enable OTel for MCP Python by removing the explicit false at schema-mapper.ts:159/:272 and the MCP special-case at actions.ts:46; keep TypeScript excluded. Validate opentelemetry-instrument cleanly wraps the streamable-http MCP server and that the backend ingests MCP-runtime spans, then refresh asset snapshots.

_Files touched:_ src/cli/operations/agent/generate/schema-mapper.ts:159 and :272; src/cli/commands/import/actions.ts:46; src/assets/python/mcp/standalone/base/pyproject.toml (add aws-opentelemetry-distro); plus snapshot refresh in src/assets/__tests__/__snapshots__/

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BUILD: OK (dist/cli/index.mjs). Adversarial reproduction by git-stashing only the two source fix files to recover ORIGINAL code, then running the real mapper functions: BEFORE (buggy) -> mapGenerateConfigToRenderConfig({protocol:MCP,language:Python}).enableOtel === false (Dockerfile {{#if enableOtel}} branch renders plain ["python","-m","main"], no OTel wrapper) AND mapGenerateConfigToAgent(...MCP Python).instrumentation === {enableOtel:false} AND src/assets/python/mcp/standalone/base/pyproject.toml dependencies = ["mcp >= 1.19.0"] only (no aws-opentelemetry-distro) -> exact silent observability gap. AFTER (fix/683, restored) -> MCP Python render.enableOtel === true (drives ["opentelemetry-instrument","python","-m","main"] CMD), mapGenerateConfigToAgent(...MCP Python) omits instrumentation entirely (schema enableOtel default=true applies; not forced off), MCP TypeScript still render.enableOtel === false and instrumentation === {enableOtel:false} (TS stays excluded), import actions.ts:46 now {enableOtel: agent.enableOtel} (no MCP special-case), pyproject + assets snapshot now include "aws-opentelemetry-distro". schema-mapper.ts:159 now gated on language==='TypeScript'; :272 enableOtel = config.language !== 'TypeScript' (!isMcp removed).

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
