### PR TITLE
fix(config): surface valid config keys in help text and invalid-key errors (#1453)

### DIFF
--- a/src/cli/commands/config/__tests__/config.test.ts
+++ b/src/cli/commands/config/__tests__/config.test.ts
@@ -1,0 +1,29 @@
+import { handleConfigSet } from '../actions';
+import { registerConfig } from '../command';
+import { CONFIG_KEYS } from '../constants';
+import { Command } from '@commander-js/extra-typings';
+import { describe, expect, it } from 'vitest';
+
+describe('config command discoverability', () => {
+  it('enumerates every valid config key in --help output', () => {
+    const program = new Command();
+    registerConfig(program);
+    const config = program.commands.find(c => c.name() === 'config')!;
+    let help = '';
+    config.configureOutput({ writeOut: s => (help += s) });
+    config.outputHelp();
+    for (const { key } of CONFIG_KEYS) {
+      expect(help).toContain(key);
+    }
+  });
+
+  it('lists valid keys in the invalid-set error', async () => {
+    const result = await handleConfigSet('notARealKey', 'x');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      for (const { key } of CONFIG_KEYS) {
+        expect(result.error.message).toContain(key);
+      }
+    }
+  });
+});

--- a/src/cli/commands/config/actions.ts
+++ b/src/cli/commands/config/actions.ts
@@ -4,6 +4,7 @@ import {
   updateGlobalConfig,
   validateGlobalConfig,
 } from '../../../lib/schemas/io/global-config.js';
+import { CONFIG_KEYS } from './constants.js';
 import type { ConfigResult } from './types.js';
 import { ValidationError } from '@/lib/index.js';
 
@@ -34,7 +35,11 @@ export async function handleConfigSet(key: string, raw: string): Promise<ConfigR
   const validation = validateGlobalConfig(partial);
 
   if (!validation.success) {
-    return { success: false, error: new ValidationError(`Invalid value "${raw}" for key "${key}".`) };
+    const validKeys = CONFIG_KEYS.map(k => k.key).join(', ');
+    return {
+      success: false,
+      error: new ValidationError(`Invalid value "${raw}" for key "${key}". Valid keys: ${validKeys}.`),
+    };
   }
 
   const ok = await updateGlobalConfig(partial);

--- a/src/cli/commands/config/command.ts
+++ b/src/cli/commands/config/command.ts
@@ -1,5 +1,6 @@
 import { COMMAND_DESCRIPTIONS } from '../../constants.js';
 import { handleConfigGet, handleConfigList, handleConfigSet } from './actions.js';
+import { formatConfigKeys } from './constants.js';
 import type { ConfigResult } from './types.js';
 import type { Command } from '@commander-js/extra-typings';
 
@@ -18,7 +19,7 @@ function printResult(result: ConfigResult): void {
 }
 
 export function registerConfig(program: Command) {
-  program
+  const config = program
     .command('config')
     .description(COMMAND_DESCRIPTIONS.config)
     .argument('[key]', 'Config key in dot notation (e.g. telemetry.enabled)')
@@ -28,4 +29,16 @@ export function registerConfig(program: Command) {
       printResult(result);
       if (!result.success) process.exit(1);
     });
+
+  config.addHelpText(
+    'after',
+    `
+Valid config keys:
+${formatConfigKeys()}
+
+Examples:
+  List config:  agentcore config
+  Get a value:  agentcore config telemetry.enabled
+  Set a value:  agentcore config telemetry.enabled true`
+  );
 }

--- a/src/cli/commands/config/constants.ts
+++ b/src/cli/commands/config/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Valid global-config keys in dot notation, mirroring the shape of
+ * GlobalConfigSchemaStrict in src/lib/schemas/io/global-config.ts. Hand-written
+ * so each key can carry a human-readable hint the schema alone cannot provide.
+ */
+export const CONFIG_KEYS: readonly { key: string; description: string }[] = [
+  { key: 'installationId', description: 'Anonymous installation identifier (UUID)' },
+  { key: 'uvDefaultIndex', description: 'Default package index URL passed to uv' },
+  { key: 'uvIndex', description: 'Additional package index URL passed to uv' },
+  { key: 'disableTransactionSearch', description: 'Disable transaction search (boolean)' },
+  { key: 'transactionSearchIndexPercentage', description: 'Transaction search index percentage (integer 0-100)' },
+  { key: 'telemetry.enabled', description: 'Enable anonymous usage analytics (boolean)' },
+  { key: 'telemetry.endpoint', description: 'Telemetry collection endpoint URL' },
+  { key: 'telemetry.audit', description: 'Log every telemetry event locally (boolean)' },
+] as const;
+
+export function formatConfigKeys(): string {
+  const width = Math.max(...CONFIG_KEYS.map(k => k.key.length));
+  return CONFIG_KEYS.map(({ key, description }) => `  ${key.padEnd(width)}  ${description}`).join('\n');
+}


### PR DESCRIPTION
Refs aws/agentcore-cli#1453

## Issues
- **#1453** — Nothing is broken — this is an enhancement request. Users running `agentcore config [key] [value]` have no in-CLI way to discover the valid keys: `agentcore config --help` shows only a generic "Config key in dot notation (e.g. telemetry.enabled)" hint, `agentcore config` (list) prints only keys already set so unset keys are invisible, and a bad `config set` reports `Invalid value ... for key ...` without listing valid keys. The only discoverable keys today are telemetry.enabled/telemetry.audit (surfaced by the separate `agentcore telemetry` command); the rest (uvDefaultIndex, uvIndex, disableTransactionSearch, transactionSearchIndexPercentage, telemetry.endpoint, installationId) exist only in the source Zod schema.

## Root cause
Valid global-config keys live only in the internal Zod schema GlobalConfigSchemaStrict (src/lib/schemas/io/global-config.ts:15-31) and are never enumerated to users; registerConfig (src/cli/commands/config/command.ts:20-31) has no addHelpText, handleConfigList (src/cli/commands/config/actions.ts:10-16) prints only persisted keys, and the invalid-set error (actions.ts:37) lists no valid keys. Verified at HEAD e92c79a4 / v0.20.2.

## The fix
Surface keys from the existing schema. Add program.addHelpText('after', ...) in registerConfig (command.ts) enumerating valid dot-notation keys with type hints and examples — mirroring the existing telemetry/command.ts:13-27 pattern. Enrich the actions.ts:37 invalid-set error to append the valid key list. Optionally add a `--all` flag or `config keys` action so handleConfigList shows every valid key (set and unset). Design decision: derive the key list by reflecting over the ZodObject shape of GlobalConfigSchemaStrict (recursing into nested telemetry) vs. maintaining a hand-written KEY_DESCRIPTIONS constant; a hand-written constant with descriptions is simpler and lets each key carry a human-readable hint, which the schema alone cannot provide.

_Files touched:_ src/cli/commands/config/command.ts (registerConfig: add addHelpText/examples, mirror telemetry/command.ts pattern); src/cli/commands/config/actions.ts (handleConfigSet line 37 for richer invalid-key error; handleConfigList lines 10-16 for optional show-all); valid keys derived from GlobalConfigSchemaStrict in src/lib/schemas/io/global-config.ts:15-31; optionally a KEY_DESCRIPTIONS constant in src/cli/commands/config/ and/or update src/cli/constants.ts:41 config description; optionally add a config section to docs/commands.md

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> Reproduced original duplicate-guard symptom against pre-fix source (git show HEAD: command.ts had no addHelpText; actions.ts error was just `Invalid value "x" for key "...".`). The new unit test src/cli/commands/config/__tests__/config.test.ts goes RED against pre-fix code: both `enumerates every valid config key in --help output` and `lists valid keys in the invalid-set error` fail (AssertionError: expected 'Invalid value "x" for key "notARealKe…' to contain 'installationId'). POST-FIX, running the actual built binary /local/home/aidandal/workplace/issues/bugfix-run/clusters/1453/repo/dist/cli/index.mjs: (1) `config --help` now prints a 'Valid config keys:' section enumerating all 8 dot-notation keys derived from GlobalConfigSchemaStrict (installationId, uvDefaultIndex, uvIndex, disableTransactionSearch, transactionSearchIndexPercentage, telemetry.enabled, telemetry.endpoint, telemetry.audit) via addHelpText('after', ...) mirroring the telemetry command pattern; (2) `config notARealKey x` now errors with `Invalid value "x" for key "notARealKey". Valid keys: installationId, uvDefaultIndex, uvIndex, disableTransactionSearch, transactionSearchIndexPercentage, telemetry.enabled, telemetry.endpoint, telemetry.audit.`. The new test passes post-fix. CONFIG_KEYS in src/cli/commands/config/constants.ts matches GlobalConfigSchemaStrict exactly (verified against src/lib/schemas/io/global-config.ts lines 15-31).

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
