### PR TITLE
fix(cli): In load-dev-env.ts, resolve the deployed target region fr... (#1457)

### DIFF
--- a/src/cli/operations/dev/__tests__/load-dev-env.test.ts
+++ b/src/cli/operations/dev/__tests__/load-dev-env.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockReadDeployedState, mockReadAWSDeploymentTargets, mockReadProjectSpec, mockFindConfigRoot, mockReadEnvFile } =
+  vi.hoisted(() => ({
+    mockReadDeployedState: vi.fn(),
+    mockReadAWSDeploymentTargets: vi.fn(),
+    mockReadProjectSpec: vi.fn(),
+    mockFindConfigRoot: vi.fn(),
+    mockReadEnvFile: vi.fn(),
+  }));
+
+const libMock = {
+  ConfigIO: class {
+    readDeployedState = mockReadDeployedState;
+    readAWSDeploymentTargets = mockReadAWSDeploymentTargets;
+    readProjectSpec = mockReadProjectSpec;
+  },
+  findConfigRoot: mockFindConfigRoot,
+  readEnvFile: mockReadEnvFile,
+};
+
+vi.mock('../../../../lib', () => libMock);
+vi.mock('../../../../lib/index.js', () => libMock);
+
+const { loadDevEnv } = await import('../load-dev-env.js');
+
+const deployedStateInUsWest2 = {
+  targets: { default: { resources: { memories: {} } } },
+};
+const usWest2Targets = [{ name: 'default', region: 'us-west-2' }];
+
+describe('loadDevEnv region injection (issue #1457)', () => {
+  beforeEach(() => {
+    mockFindConfigRoot.mockReturnValue('/project/agentcore');
+    mockReadEnvFile.mockResolvedValue({});
+    mockReadProjectSpec.mockResolvedValue({ agentCoreGateways: [] });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.AWS_REGION;
+    delete process.env.AWS_DEFAULT_REGION;
+  });
+
+  it('injects the deployed target region even when the shell region differs', async () => {
+    process.env.AWS_REGION = 'us-east-1';
+    mockReadDeployedState.mockResolvedValue(deployedStateInUsWest2);
+    mockReadAWSDeploymentTargets.mockResolvedValue(usWest2Targets);
+
+    const { envVars } = await loadDevEnv('/project');
+
+    expect(envVars.AWS_REGION).toBe('us-west-2');
+    expect(envVars.AWS_DEFAULT_REGION).toBe('us-west-2');
+  });
+
+  it('lets an explicit AWS_REGION in the project .env override the target region', async () => {
+    mockReadDeployedState.mockResolvedValue(deployedStateInUsWest2);
+    mockReadAWSDeploymentTargets.mockResolvedValue(usWest2Targets);
+    mockReadEnvFile.mockResolvedValue({ AWS_REGION: 'eu-west-1' });
+
+    const { envVars } = await loadDevEnv('/project');
+
+    expect(envVars.AWS_REGION).toBe('eu-west-1');
+  });
+
+  it('omits region vars (and does not throw) when aws-targets is unreadable', async () => {
+    mockReadDeployedState.mockRejectedValue(new Error('no state'));
+    mockReadAWSDeploymentTargets.mockRejectedValue(new Error('no targets'));
+
+    const { envVars } = await loadDevEnv('/project');
+
+    expect(envVars.AWS_REGION).toBeUndefined();
+    expect(envVars.AWS_DEFAULT_REGION).toBeUndefined();
+  });
+});

--- a/src/cli/operations/dev/load-dev-env.ts
+++ b/src/cli/operations/dev/load-dev-env.ts
@@ -3,6 +3,7 @@ import type { AgentEnvSpec } from '../../../schema';
 import { getGatewayEnvVars } from './gateway-env.js';
 import { getMemoryEnvVars } from './memory-env.js';
 import { getPaymentEnvVars } from './payment-env.js';
+import { getRegionEnvVars } from './region-env.js';
 
 export interface DevEnv {
   /** Merged env vars: deployed-state (gateway + memory + payment) first, then .env overrides */
@@ -21,12 +22,13 @@ export interface DevEnv {
 export async function loadDevEnv(workingDir: string, runtime?: AgentEnvSpec): Promise<DevEnv> {
   const configRoot = findConfigRoot(workingDir);
   const dotEnvVars = configRoot ? await readEnvFile(configRoot) : {};
+  const regionEnvVars = await getRegionEnvVars();
   const gatewayEnvVars = await getGatewayEnvVars();
   const memoryEnvVars = await getMemoryEnvVars();
   const paymentEnvVars = await getPaymentEnvVars(runtime);
 
   return {
-    envVars: { ...gatewayEnvVars, ...memoryEnvVars, ...paymentEnvVars, ...dotEnvVars },
+    envVars: { ...regionEnvVars, ...gatewayEnvVars, ...memoryEnvVars, ...paymentEnvVars, ...dotEnvVars },
     deployedMemoryCount: Object.keys(memoryEnvVars).length,
   };
 }

--- a/src/cli/operations/dev/region-env.ts
+++ b/src/cli/operations/dev/region-env.ts
@@ -1,0 +1,31 @@
+import { ConfigIO } from '../../../lib/index.js';
+
+/**
+ * Resolve the deployed target's region as AWS_REGION / AWS_DEFAULT_REGION env
+ * vars for dev mode. Deployed resources (e.g. AgentCore Memory) live in the
+ * region recorded in aws-targets.json, but the local agent's AWS SDK falls back
+ * to the shell's AWS_REGION otherwise — so a shell region that is unset or
+ * differs from the deployed region makes calls like ListEvents hit the wrong
+ * region and fail with "Memory not found" (see issue #1457).
+ *
+ * Uses the same target the dev path already resolves: the first target in
+ * deployed state, matched against aws-targets.json by name.
+ */
+export async function getRegionEnvVars(): Promise<Record<string, string>> {
+  const configIO = new ConfigIO();
+
+  try {
+    const deployedState = await configIO.readDeployedState();
+    const targetName = Object.keys(deployedState?.targets ?? {})[0];
+    if (!targetName) return {};
+
+    const awsTargets = await configIO.readAWSDeploymentTargets();
+    const region = awsTargets.find(t => t.name === targetName)?.region;
+    if (!region) return {};
+
+    return { AWS_REGION: region, AWS_DEFAULT_REGION: region };
+  } catch {
+    // No deployed state or targets — leave region resolution to the SDK default chain
+    return {};
+  }
+}


### PR DESCRIPTION
Refs aws/agentcore-cli#1457

## Issues
- **#1457** — When a user runs `agentcore dev` against an agent that uses AgentCore Memory, and their shell's AWS region (AWS_REGION/AWS_DEFAULT_REGION, or none set) differs from the region where the memory was actually deployed (per aws-targets.json), the local agent calls ListEvents in the wrong region and fails hard with ResourceNotFoundException ("Memory not found"). The deployed memory ID is injected correctly, but the region it lives in is not, so invocations break in a confusing way during local dev. Single-region users whose shell region matches the target are unaffected.

## Root cause
CLI dev path injects deployed memory ID but never the deployed target region: load-dev-env.ts:21-32 merges gateway/memory/payment+.env only (no region logic, no region-env.ts); codezip-dev-server.ts:138 builds subprocess env as {...process.env, ...envVars, PORT, LOCAL_DEV}; vended asset session.py:9 reads REGION=os.getenv('AWS_REGION'). applyTargetRegionToEnv (target-region.ts:23, fix for #924) is wired only into deploy/actions.ts:171, teardown.ts:73, useCdkPreflight.ts:410 — never the dev command. Container path (container-dev-server.ts:182-195) forwards region only from process.env, same gap. SDK is correct (session_manager.py:146-147 uses the region it's given, defaulting to boto3 chain when None).

## The fix
In load-dev-env.ts resolve the target region from aws-targets.json (same read as browser-mode.ts:43-53) and add AWS_REGION/AWS_DEFAULT_REGION to returned envVars before the .env spread (deployed target authoritative, user .env can still override). Single injection point covers CodeZip (codezip-dev-server.ts:138) and Container (container-dev-server.ts:216/224-230) and all entry points (command.tsx:388, useDevServer.ts:114, browser-mode.ts:162/242). No SDK/asset change. Multi-target: pick the same target the dev path already uses (targets[0]). Add a unit test.

_Files touched:_ src/cli/operations/dev/load-dev-env.ts (primary; optionally a new src/cli/operations/dev/region-env.ts). Reuse aws-targets read from src/cli/commands/dev/browser-mode.ts:43-53 and the AWS_REGION helper concept in src/cli/aws/target-region.ts:23.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (fix stashed; pre-fix load-dev-env.ts merges only {...gatewayEnvVars, ...memoryEnvVars, ...paymentEnvVars, ...dotEnvVars} with no region injection): the issue-#1457 unit test FAILS — `expect(envVars.AWS_REGION).toBe('us-west-2')` → AssertionError "expected undefined to be 'us-west-2'", even though deployedState's first target maps to region us-west-2 in aws-targets.json and the shell has process.env.AWS_REGION=us-east-1. This is the exact symptom: deployed target region is never injected, SDK falls back to the shell/boto3 region, ListEvents hits the wrong region. (The .env-override and absent-targets tests trivially pass pre-fix because no region var is added at all.) AFTER (fix restored): load-dev-env.ts now spreads `...regionEnvVars` FIRST via new getRegionEnvVars() from region-env.ts; all 3 tests pass — AWS_REGION/AWS_DEFAULT_REGION=us-west-2 injected despite shell us-east-1; explicit .env AWS_REGION=eu-west-1 still overrides (region spread before dotEnv spread); absent/unreadable aws-targets.json omits region vars and does not throw. region-env.ts sources region identically to browser-mode.ts:43-53 (awsTargets.find(t=>t.name===targetName).region on the first deployed target, try/catch -> {}). Build: OK dist/cli/index.mjs (exit 0).

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
