### PR TITLE
fix(cli): vend starter entrypoint for BYO agents (#629)

### DIFF
--- a/src/cli/commands/add/__tests__/add-agent.test.ts
+++ b/src/cli/commands/add/__tests__/add-agent.test.ts
@@ -272,6 +272,49 @@ describe('add agent command', () => {
       const agent = projectSpec.runtimes.find((a: { name: string }) => a.name === agentName);
       expect(agent, 'Agent should be in agentcore.json').toBeTruthy();
       expect(agent.codeLocation.includes(codeDir), `codeLocation should reference ${codeDir}`).toBeTruthy();
+
+      // Existing user code must not be overwritten by the starter stub
+      const entrypoint = await readFile(join(projectDir, codeDir, 'main.py'), 'utf-8');
+      expect(entrypoint).toBe('# existing code\n');
+    });
+
+    it('vends a runtime-contract starter at the resolved --entrypoint for a fresh Python BYO agent', async () => {
+      const agentName = `ByoStub${Date.now()}`;
+      const codeDir = `stub-agent-${Date.now()}`;
+
+      const result = await runCLI(
+        [
+          'add',
+          'agent',
+          '--name',
+          agentName,
+          '--type',
+          'byo',
+          '--code-location',
+          codeDir,
+          '--entrypoint',
+          'agent.py',
+          '--language',
+          'Python',
+          '--framework',
+          'Strands',
+          '--model-provider',
+          'Bedrock',
+          '--json',
+        ],
+        projectDir
+      );
+
+      expect(result.exitCode, `stdout: ${result.stdout}`).toBe(0);
+
+      // Honors --entrypoint: written to agent.py, not a hardcoded main.py
+      expect(await exists(join(projectDir, codeDir, 'main.py'))).toBe(false);
+      const entrypoint = await readFile(join(projectDir, codeDir, 'agent.py'), 'utf-8');
+      expect(entrypoint).toContain('from bedrock_agentcore.runtime import BedrockAgentCoreApp');
+      expect(entrypoint).toContain('app = BedrockAgentCoreApp()');
+      expect(entrypoint).toContain('@app.entrypoint');
+      expect(entrypoint).toContain('app.run()');
+      expect(entrypoint).not.toContain('def handler(event, context)');
     });
 
     it('requires code-location for BYO path', async () => {

--- a/src/cli/primitives/AgentPrimitive.tsx
+++ b/src/cli/primitives/AgentPrimitive.tsx
@@ -74,12 +74,13 @@ import { requireTTY } from '../tui/guards/tty';
 import type { GenerateConfig, MemoryOption } from '../tui/screens/generate/types';
 import { BasePrimitive } from './BasePrimitive';
 import { CredentialPrimitive } from './CredentialPrimitive';
+import { BYO_PYTHON_ENTRYPOINT_STUB, BYO_TYPESCRIPT_ENTRYPOINT_STUB } from './constants';
 import { buildAuthorizerConfigFromJwtConfig, createManagedOAuthCredential } from './auth-utils';
 import { computeDefaultCredentialEnvVarName } from './credential-utils';
 import type { AddResult, AddScreenComponent, RemovableResource } from './types';
 import { DescribeSubnetsCommand, EC2Client } from '@aws-sdk/client-ec2';
 import type { Command } from '@commander-js/extra-typings';
-import { mkdirSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 /**
@@ -671,6 +672,23 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
     const codeDir = join(projectRoot, codeLocation.replace(/\/$/, ''));
     mkdirSync(codeDir, { recursive: true });
 
+    // Vend a starter entrypoint following the AgentCore runtime contract so `agentcore dev`
+    // works out of the box. Never overwrite existing user code; skip for non-Python/TS.
+    const entrypoint = options.entrypoint ?? 'main.py';
+    const stub =
+      options.language === 'Python'
+        ? BYO_PYTHON_ENTRYPOINT_STUB
+        : options.language === 'TypeScript'
+          ? BYO_TYPESCRIPT_ENTRYPOINT_STUB
+          : undefined;
+    // Entrypoint may carry a "file.py:handler" suffix and a subdirectory path.
+    const entrypointFile = entrypoint.split(':')[0]!;
+    const entrypointPath = join(codeDir, entrypointFile);
+    if (stub && !existsSync(entrypointPath)) {
+      mkdirSync(dirname(entrypointPath), { recursive: true });
+      writeFileSync(entrypointPath, stub);
+    }
+
     const project = await configIO.readProjectSpec();
 
     const protocol = options.protocol ?? 'HTTP';
@@ -711,7 +729,7 @@ export class AgentPrimitive extends BasePrimitive<AddAgentOptions, RemovableReso
     const agent: AgentEnvSpec = {
       name: options.name,
       build: options.buildType,
-      entrypoint: (options.entrypoint ?? 'main.py') as FilePath,
+      entrypoint: entrypoint as FilePath,
       codeLocation: codeLocation as DirectoryPath,
       runtimeVersion: DEFAULT_PYTHON_VERSION,
       protocol,

--- a/src/cli/primitives/constants.ts
+++ b/src/cli/primitives/constants.ts
@@ -7,3 +7,43 @@ export const PASSTHROUGH_PROTOCOL_TYPES = ['MCP', 'A2A', 'INFERENCE', 'CUSTOM'] 
 
 /** Error shown when `--additional-params` is not parseable as a JSON object (lite_llm harness). */
 export const ADDITIONAL_PARAMS_JSON_ERROR = '--additional-params must be a valid JSON object';
+
+/**
+ * Starter entrypoint vended into a BYO Python agent's code directory so `agentcore dev`
+ * works out of the box. Follows the AgentCore runtime contract (BedrockAgentCoreApp /
+ * @app.entrypoint / app.run), not a Lambda-style handler.
+ */
+export const BYO_PYTHON_ENTRYPOINT_STUB = `from bedrock_agentcore.runtime import BedrockAgentCoreApp
+
+app = BedrockAgentCoreApp()
+
+
+@app.entrypoint
+def invoke(payload, context):
+    """Replace this with your agent logic."""
+    prompt = payload.get("prompt", "")
+    return {"result": f"Echo: {prompt}"}
+
+
+if __name__ == "__main__":
+    app.run()
+`;
+
+/**
+ * Starter entrypoint vended into a BYO TypeScript agent's code directory. Follows the
+ * AgentCore runtime contract via the TypeScript SDK's BedrockAgentCoreApp.
+ */
+export const BYO_TYPESCRIPT_ENTRYPOINT_STUB = `import { BedrockAgentCoreApp } from 'bedrock-agentcore/runtime';
+
+const app = new BedrockAgentCoreApp({
+  invocationHandler: {
+    // Replace this with your agent logic.
+    async process(payload: any, context: any) {
+      const prompt = payload?.prompt ?? '';
+      return { result: \`Echo: \${prompt}\` };
+    },
+  },
+});
+
+app.run({ port: parseInt(process.env.PORT ?? '8080') });
+`;

--- a/src/cli/tui/screens/add/AddFlow.tsx
+++ b/src/cli/tui/screens/add/AddFlow.tsx
@@ -140,16 +140,25 @@ function AgentAddedSummary({
           </Text>
         </Box>
       )}
-      {!isCreate && (
-        <Box flexDirection="column" marginTop={1}>
-          <Text color="yellow">
-            Copy your agent code to <Text color="cyan">{config.codeLocation}</Text> before deploying.
-          </Text>
-          <Text dimColor>
-            Ensure <Text color="cyan">{config.entrypoint}</Text> is the entrypoint file in that folder.
-          </Text>
-        </Box>
-      )}
+      {!isCreate &&
+        (config.language === 'Python' || config.language === 'TypeScript' ? (
+          <Box flexDirection="column" marginTop={1}>
+            <Text dimColor>
+              Your agent entrypoint is <Text color="cyan">{config.entrypoint}</Text> in{' '}
+              <Text color="cyan">{config.codeLocation}</Text>. A starter was added if it did not already exist — edit it
+              with your agent logic.
+            </Text>
+          </Box>
+        ) : (
+          <Box flexDirection="column" marginTop={1}>
+            <Text color="yellow">
+              Copy your agent code to <Text color="cyan">{config.codeLocation}</Text> before deploying.
+            </Text>
+            <Text dimColor>
+              Ensure <Text color="cyan">{config.entrypoint}</Text> is the entrypoint file in that folder.
+            </Text>
+          </Box>
+        ))}
       {isImport && config.bedrockAgentId && (
         <Box marginTop={1}>
           <Text dimColor>

--- a/src/cli/tui/screens/create/CreateScreen.tsx
+++ b/src/cli/tui/screens/create/CreateScreen.tsx
@@ -94,8 +94,15 @@ function buildExitMessage(
 
   // BYO code location reminder
   if (agentConfig?.agentType === 'byo') {
-    lines.push(`\x1b[33mCopy your agent code to \x1b[36m${agentConfig.codeLocation}\x1b[33m before deploying.\x1b[0m`);
-    lines.push(`\x1b[2mEnsure \x1b[36m${agentConfig.entrypoint}\x1b[2m is the entrypoint file in that folder.\x1b[0m`);
+    const vendedStub = agentConfig.language === 'Python' || agentConfig.language === 'TypeScript';
+    if (vendedStub) {
+      lines.push(
+        `\x1b[2mYour agent entrypoint is \x1b[36m${agentConfig.entrypoint}\x1b[2m in \x1b[36m${agentConfig.codeLocation}\x1b[2m. A starter was added if it didn't already exist — edit it with your agent logic.\x1b[0m`
+      );
+    } else {
+      lines.push(`\x1b[33mCopy your agent code to \x1b[36m${agentConfig.codeLocation}\x1b[33m before deploying.\x1b[0m`);
+      lines.push(`\x1b[2mEnsure \x1b[36m${agentConfig.entrypoint}\x1b[2m is the entrypoint file in that folder.\x1b[0m`);
+    }
     lines.push('');
   }
 


### PR DESCRIPTION
Refs aws/agentcore-cli#629

## Issues
- **#629** — When creating a Bring-Your-Own agent (agentcore create or agentcore add agent --type byo), the CLI makes an empty code directory and only prints a reminder to add the entrypoint yourself. Unlike every template agent type, BYO vends no starter file, so a new user has nothing to run and agentcore dev fails until they hand-author main.py with the right contract. This is an onboarding paper-cut, not a functional defect.

## Root cause
handleByoPath() only mkdirSyncs the code dir at AgentPrimitive.tsx:672 and vends no entrypoint, vs handleCreatePath() which renders a full template at :603-605 — confirmed byte-identical at v0.20.2 via git diff/show; entrypoint contract (BedrockAgentCoreApp/@app.entrypoint/app.run) verified in vended main.py:52,77,510,671 and SDK app.py:213,644.

## The fix
In handleByoPath() after the mkdirSync at AgentPrimitive.tsx:672, write a starter entrypoint file at join(codeDir, options.entrypoint ?? 'main.py') only when it does not already exist (never overwrite user code). The stub MUST follow the real AgentCore contract, NOT a Lambda handler: from bedrock_agentcore.runtime import BedrockAgentCoreApp; app = BedrockAgentCoreApp(); @app.entrypoint def invoke(payload, context): ...; if __name__ == '__main__': app.run(). Two required design decisions: (1) BYO supports --language Python/TypeScript/Other (AgentPrimitive.tsx:260) so gate on language — Python stub for Python, optional TS stub for TypeScript, skip for Other; (2) the filename is user-configurable via --entrypoint (AgentPrimitive.tsx:270, resolved at line 714) so write to the resolved entrypoint name, not a hardcoded main.py. Cleanest implementation is a small BYO placeholder asset under src/assets/ plus a renderer in src/cli/templates/ for consistency with the existing template pipeline; the reminder text at CreateScreen.tsx:98-99 and AddFlow.tsx:145-150 can be softened once a placeholder exists. NOTE: the issue's own suggested stub def handler(event, context): return {'statusCode': 200} is WRONG for this runtime and would fail the 'agentcore dev works out of the box' acceptance criterion.

_Files touched:_ /local/home/aidandal/workplace/issues/agentcore-cli/src/cli/primitives/AgentPrimitive.tsx — handleByoPath() (lines 662-743), add placeholder-file write after mkdirSync at line 672 using the entrypoint resolved at line 714. Optionally add a BYO placeholder asset under src/assets/ + renderer in src/cli/templates/. Reminders at src/cli/tui/screens/create/CreateScreen.tsx:98-99 and src/cli/tui/screens/add/AddFlow.tsx:145-150 may be softened.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (fix stashed + rebuilt): `agentcore add agent --type byo --name myagent --language Python --code-location ./src/myagent --framework Strands --model-provider Bedrock` created src/myagent/ EMPTY (0 files) — no entrypoint vended. Confirmed in source: original handleByoPath only did mkdirSync(codeDir).

AFTER (fix restored + rebuilt, run by dist/cli/index.mjs):
- Same command produces src/myagent/main.py (304B) with the AgentCore runtime contract: `from bedrock_agentcore.runtime import BedrockAgentCoreApp`, `app = BedrockAgentCoreApp()`, `@app.entrypoint def invoke(payload, context)`, `app.run()` under `if __name__ == "__main__"`; contains NO `def handler(event, context)`.
- --entrypoint agent.py honored: stub written to agent.py, no main.py created (resolved name, not hardcoded).
- Pre-existing main.py with hand-written content NOT overwritten (verified byte-for-byte unchanged).
- --language Other: no stub written (0 files), dir still created as before.
- --language TypeScript --entrypoint index.ts: TS stub vended (380B) using BedrockAgentCoreApp from 'bedrock-agentcore/runtime'.
- Contract executed: importing the vended main.py yields a real BedrockAgentCoreApp instance; invoke({'prompt':'hello'}, ctx) returns {'result':'Echo: hello'}; no `handler` attribute.
- agentcore dev out-of-the-box: with a minimal pyproject.toml declaring bedrock-agentcore (as template agents ship), dev server booted, /ping -> 200, and invocation returned {"result":"Echo: validator ping"} both vi

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
