### PR TITLE
fix(unit-only): Add a secretless link path in pre-deploy-identity.ts: in ... (#1032)

### DIFF
--- a/src/cli/operations/deploy/__tests__/pre-deploy-identity.test.ts
+++ b/src/cli/operations/deploy/__tests__/pre-deploy-identity.test.ts
@@ -12,7 +12,9 @@ const {
   mockSetTokenVaultKmsKey,
   mockReadEnvFile,
   mockGetCredentialProvider,
+  mockGetApiKeyProvider,
   mockOAuth2ProviderExists,
+  mockGetOAuth2Provider,
   mockCreateOAuth2Provider,
   mockUpdateOAuth2Provider,
 } = vi.hoisted(() => ({
@@ -21,7 +23,9 @@ const {
   mockSetTokenVaultKmsKey: vi.fn(),
   mockReadEnvFile: vi.fn(),
   mockGetCredentialProvider: vi.fn(),
+  mockGetApiKeyProvider: vi.fn(),
   mockOAuth2ProviderExists: vi.fn(),
+  mockGetOAuth2Provider: vi.fn(),
   mockCreateOAuth2Provider: vi.fn(),
   mockUpdateOAuth2Provider: vi.fn(),
 }));
@@ -47,9 +51,11 @@ vi.mock('@aws-sdk/client-bedrock-agentcore-control', () => ({
 vi.mock('../../identity/index.js', () => ({
   apiKeyProviderExists: vi.fn(),
   createApiKeyProvider: vi.fn(),
+  getApiKeyProvider: mockGetApiKeyProvider,
   setTokenVaultKmsKey: mockSetTokenVaultKmsKey,
   updateApiKeyProvider: vi.fn(),
   oAuth2ProviderExists: mockOAuth2ProviderExists,
+  getOAuth2Provider: mockGetOAuth2Provider,
   createOAuth2Provider: mockCreateOAuth2Provider,
   updateOAuth2Provider: mockUpdateOAuth2Provider,
 }));
@@ -206,6 +212,56 @@ describe('setupApiKeyProviders - KMS key reuse via GetTokenVault', () => {
   });
 });
 
+describe('setupApiKeyCredentialProvider - secretless linking', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  beforeEach(() => {
+    mockReadEnvFile.mockResolvedValue({});
+    mockGetCredentialProvider.mockReturnValue({});
+  });
+
+  const projectSpec = {
+    name: 'test-project',
+    credentials: [{ name: 'openai', authorizerType: 'ApiKeyCredentialProvider' }],
+    runtimes: [],
+  };
+
+  it('links an existing provider by name when no local secret exists', async () => {
+    mockGetApiKeyProvider.mockResolvedValue({
+      success: true,
+      credentialProviderArn: 'arn:aws:bedrock-agentcore:us-east-1:123:credential-provider/openai',
+    });
+
+    const result = await setupApiKeyProviders({
+      projectSpec: projectSpec as any,
+      configBaseDir: '/tmp',
+      region: 'us-east-1',
+    });
+
+    expect(result.hasErrors).toBe(false);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]!.status).toBe('linked');
+    expect(result.results[0]!.credentialProviderArn).toBe(
+      'arn:aws:bedrock-agentcore:us-east-1:123:credential-provider/openai'
+    );
+    expect(mockGetApiKeyProvider).toHaveBeenCalledWith(expect.anything(), 'openai');
+  });
+
+  it('errors when no local secret and no remote provider exists', async () => {
+    mockGetApiKeyProvider.mockResolvedValue({ success: false, error: new Error('ResourceNotFoundException') });
+
+    const result = await setupApiKeyProviders({
+      projectSpec: projectSpec as any,
+      configBaseDir: '/tmp',
+      region: 'us-east-1',
+    });
+
+    expect(result.hasErrors).toBe(true);
+    expect(result.results[0]!.status).toBe('error');
+    expect(result.results[0]!.error?.message).toContain('no existing AgentCore Identity API key credential provider');
+  });
+});
+
 describe('hasIdentityOAuthProviders', () => {
   it('returns true when OAuthCredentialProvider exists', () => {
     const projectSpec = {
@@ -280,6 +336,38 @@ describe('setupOAuth2Providers', () => {
     vi.clearAllMocks();
   });
 
+  it('links an existing OAuth2 provider by name when client credentials are missing', async () => {
+    mockReadEnvFile.mockResolvedValue({});
+    mockGetOAuth2Provider.mockResolvedValue({
+      success: true,
+      credentialProviderArn: 'arn:aws:bedrock-agentcore:us-east-1:123:credential-provider/test-oauth',
+      clientSecretArn: 'arn:aws:secretsmanager:us-east-1:123:secret:test-oauth',
+      callbackUrl: 'https://callback.example.com',
+    });
+
+    const projectSpec = {
+      credentials: [{ name: 'test-oauth', authorizerType: 'OAuthCredentialProvider' }],
+    };
+
+    const result = await setupOAuth2Providers({
+      projectSpec: projectSpec as any,
+      configBaseDir: '/tmp',
+      region: 'us-east-1',
+    });
+
+    expect(result.hasErrors).toBe(false);
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]!.status).toBe('linked');
+    expect(result.results[0]!.credentialProviderArn).toBe(
+      'arn:aws:bedrock-agentcore:us-east-1:123:credential-provider/test-oauth'
+    );
+    expect(result.results[0]!.clientSecretArn).toBe('arn:aws:secretsmanager:us-east-1:123:secret:test-oauth');
+    expect(result.results[0]!.callbackUrl).toBe('https://callback.example.com');
+    expect(mockGetOAuth2Provider).toHaveBeenCalledWith(expect.anything(), 'test-oauth');
+    expect(mockCreateOAuth2Provider).not.toHaveBeenCalled();
+    expect(mockUpdateOAuth2Provider).not.toHaveBeenCalled();
+  });
+
   it('creates OAuth2 provider when it does not exist', async () => {
     mockReadEnvFile.mockResolvedValue({
       AGENTCORE_CREDENTIAL_TEST_OAUTH_CLIENT_ID: 'client123',
@@ -350,8 +438,9 @@ describe('setupOAuth2Providers', () => {
     expect(mockUpdateOAuth2Provider).toHaveBeenCalled();
   });
 
-  it('skips when env vars are missing', async () => {
+  it('errors when env vars are missing and provider cannot be linked', async () => {
     mockReadEnvFile.mockResolvedValue({});
+    mockGetOAuth2Provider.mockResolvedValue({ success: false, error: new Error('ResourceNotFoundException') });
 
     const projectSpec = {
       credentials: [{ name: 'test-oauth', authorizerType: 'OAuthCredentialProvider' }],
@@ -363,10 +452,11 @@ describe('setupOAuth2Providers', () => {
       region: 'us-east-1',
     });
 
-    expect(result.hasErrors).toBe(false);
+    expect(result.hasErrors).toBe(true);
     expect(result.results).toHaveLength(1);
-    expect(result.results[0]!.status).toBe('skipped');
+    expect(result.results[0]!.status).toBe('error');
     expect(result.results[0]!.error?.message).toContain('Missing');
+    expect(result.results[0]!.error?.message).toContain('no existing AgentCore Identity OAuth2 credential provider');
   });
 
   it('returns error on failure', async () => {

--- a/src/cli/operations/deploy/pre-deploy-identity.ts
+++ b/src/cli/operations/deploy/pre-deploy-identity.ts
@@ -26,6 +26,8 @@ import {
   apiKeyProviderExists,
   createApiKeyProvider,
   createOAuth2Provider,
+  getApiKeyProvider,
+  getOAuth2Provider,
   oAuth2ProviderExists,
   setTokenVaultKmsKey,
   updateApiKeyProvider,
@@ -43,7 +45,7 @@ import { join } from 'path';
 
 export interface ApiKeyProviderSetupResult {
   providerName: string;
-  status: 'created' | 'updated' | 'exists' | 'skipped' | 'error';
+  status: 'created' | 'updated' | 'exists' | 'linked' | 'skipped' | 'error';
   credentialProviderArn?: string;
   error?: Error;
 }
@@ -173,10 +175,24 @@ async function setupApiKeyCredentialProvider(
   const apiKey = credentials.get(envVarName);
 
   if (!apiKey) {
+    // No local secret to create/update from. Link an existing provider of the same
+    // name (created in the console, another project, or via IaC) so its ARN reaches
+    // deployed state for CDK/gateway wiring.
+    const existing = await getApiKeyProvider(client, credential.name);
+    if (existing.success) {
+      return {
+        providerName: credential.name,
+        status: 'linked',
+        credentialProviderArn: existing.credentialProviderArn,
+      };
+    }
+
     return {
       providerName: credential.name,
-      status: 'skipped',
-      error: new Error(`No ${envVarName} found in agentcore/.env.local`),
+      status: 'error',
+      error: new MissingCredentialsError(
+        `No ${envVarName} found in agentcore/.env.local and no existing AgentCore Identity API key credential provider named "${credential.name}" was found.`
+      ),
     };
   }
 
@@ -332,7 +348,7 @@ export function assertEnvFileExists(projectSpec: AgentCoreProjectSpec, configBas
 
 export interface OAuth2ProviderSetupResult {
   providerName: string;
-  status: 'created' | 'updated' | 'skipped' | 'error';
+  status: 'created' | 'updated' | 'linked' | 'skipped' | 'error';
   error?: Error;
   credentialProviderArn?: string;
   clientSecretArn?: string;
@@ -403,21 +419,48 @@ async function setupSingleOAuth2Provider(
   const clientSecret = credentials.get(clientSecretEnvVar);
 
   if (!clientId || !clientSecret) {
+    // No local secret to create/update from. Link an existing provider of the same
+    // name (created in the console, another project, or via IaC) so its ARN reaches
+    // deployed state for CDK/gateway wiring.
+    const existing = await getOAuth2Provider(client, credential.name);
+    if (existing.success) {
+      return {
+        providerName: credential.name,
+        status: 'linked',
+        credentialProviderArn: existing.credentialProviderArn,
+        clientSecretArn: existing.clientSecretArn,
+        callbackUrl: existing.callbackUrl,
+      };
+    }
+
     return {
       providerName: credential.name,
-      status: 'skipped',
-      error: new MissingCredentialsError(`Missing ${clientIdEnvVar} or ${clientSecretEnvVar} in agentcore/.env.local`),
+      status: 'error',
+      error: new MissingCredentialsError(
+        `Missing ${clientIdEnvVar} or ${clientSecretEnvVar} in agentcore/.env.local and no existing AgentCore Identity OAuth2 credential provider named "${credential.name}" was found.`
+      ),
     };
   }
 
   // Imported OAuth providers may not have a discoveryUrl (provider already exists in Identity service).
-  // Skip create/update since we can't build a valid config without it.
+  // We can't build a valid create/update config without it, so link the existing provider by name.
   if (!credential.discoveryUrl) {
+    const existing = await getOAuth2Provider(client, credential.name);
+    if (existing.success) {
+      return {
+        providerName: credential.name,
+        status: 'linked',
+        credentialProviderArn: existing.credentialProviderArn,
+        clientSecretArn: existing.clientSecretArn,
+        callbackUrl: existing.callbackUrl,
+      };
+    }
+
     return {
       providerName: credential.name,
-      status: 'skipped',
+      status: 'error',
       error: new MissingCredentialsError(
-        `No discoveryUrl configured for "${credential.name}". Provider already exists in Identity service — credentials in .env.local will be ignored.`
+        `No discoveryUrl configured for "${credential.name}" and no existing AgentCore Identity OAuth2 credential provider with that name was found.`
       ),
     };
   }

--- a/src/cli/operations/identity/__tests__/api-key-credential-provider.test.ts
+++ b/src/cli/operations/identity/__tests__/api-key-credential-provider.test.ts
@@ -1,6 +1,7 @@
 import {
   apiKeyProviderExists,
   createApiKeyProvider,
+  getApiKeyProvider,
   setTokenVaultKmsKey,
   updateApiKeyProvider,
 } from '../api-key-credential-provider.js';
@@ -59,6 +60,26 @@ describe('apiKeyProviderExists', () => {
     mockSend.mockRejectedValue(new Error('other error'));
 
     await expect(apiKeyProviderExists(makeMockClient(), 'my-provider')).rejects.toThrow('other error');
+  });
+});
+
+describe('getApiKeyProvider', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns the credentialProviderArn when provider exists', async () => {
+    mockSend.mockResolvedValue({ credentialProviderArn: 'arn:aws:bedrock:us-east-1:123:provider/prov' });
+
+    expect(await getApiKeyProvider(makeMockClient(), 'prov')).toEqual({
+      success: true,
+      credentialProviderArn: 'arn:aws:bedrock:us-east-1:123:provider/prov',
+    });
+  });
+
+  it('returns failure when provider does not exist', async () => {
+    mockSend.mockRejectedValue(new MockResourceNotFoundException());
+
+    const result = await getApiKeyProvider(makeMockClient(), 'prov');
+    expect(result.success).toBe(false);
   });
 });
 

--- a/src/cli/operations/identity/api-key-credential-provider.ts
+++ b/src/cli/operations/identity/api-key-credential-provider.ts
@@ -35,6 +35,26 @@ export async function apiKeyProviderExists(
 }
 
 /**
+ * Get an existing API key credential provider's ARN by name.
+ * Used to link a provider that was created outside the project (console, another
+ * project, IaC) when no local secret is available to create/update it.
+ */
+export async function getApiKeyProvider(
+  client: BedrockAgentCoreControlClient,
+  providerName: string
+): Promise<Result<{ credentialProviderArn: string }>> {
+  try {
+    const response = await client.send(new GetApiKeyCredentialProviderCommand({ name: providerName }));
+    if (!response.credentialProviderArn) {
+      return err(toError('No credentialProviderArn in response'));
+    }
+    return ok({ credentialProviderArn: response.credentialProviderArn });
+  } catch (error) {
+    return err(toError(error));
+  }
+}
+
+/**
  * Create an API key credential provider.
  * Returns success even if provider already exists (idempotent).
  */

--- a/src/cli/operations/identity/index.ts
+++ b/src/cli/operations/identity/index.ts
@@ -1,6 +1,7 @@
 export {
   apiKeyProviderExists,
   createApiKeyProvider,
+  getApiKeyProvider,
   setTokenVaultKmsKey,
   updateApiKeyProvider,
 } from './api-key-credential-provider';

--- a/src/cli/tui/hooks/useCdkPreflight.ts
+++ b/src/cli/tui/hooks/useCdkPreflight.ts
@@ -799,6 +799,8 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               logger.log(`Updated API key provider: ${result.providerName}`);
             } else if (result.status === 'exists') {
               logger.log(`API key provider exists: ${result.providerName}`);
+            } else if (result.status === 'linked') {
+              logger.log(`Linked API key provider: ${result.providerName}`);
             } else if (result.status === 'skipped') {
               logger.log(`Skipped ${result.providerName}: ${result.error?.message}`);
             } else if (result.status === 'error') {
@@ -842,6 +844,8 @@ export function useCdkPreflight(options: PreflightOptions): PreflightResult {
               logger.log(`Created OAuth provider: ${result.providerName}`);
             } else if (result.status === 'updated') {
               logger.log(`Updated OAuth provider: ${result.providerName}`);
+            } else if (result.status === 'linked') {
+              logger.log(`Linked OAuth provider: ${result.providerName}`);
             } else if (result.status === 'skipped') {
               logger.log(`Skipped ${result.providerName}: ${result.error?.message}`);
             } else if (result.status === 'error') {


### PR DESCRIPTION
Refs aws/agentcore-cli#1032

## Issues
- **#1032** — When a project references an AgentCore Identity credential provider that is managed outside the project (created in the console, another project, or IaC) and there is no matching local secret in agentcore/.env.local, `agentcore deploy` cannot wire that provider's ARN. If a gateway target's outbound auth references such a credential, deploy fails at CDK synth with `Credential "X" not found in deployed state`. This is an enhancement gap, not a regression: the normal create/update-from-local-secret path works, and putting the secret in .env.local is a workaround.

## Root cause
CLI-side, confirmed by reading v0.20.2. setupApiKeyCredentialProvider returns status:'skipped' with no credentialProviderArn when the local secret is absent (src/cli/operations/deploy/pre-deploy-identity.ts:175-181); same for OAuth at lines 405-411 (missing client id/secret) and 415-423 (no discoveryUrl). The ARN-collection loops only persist a credential when result.credentialProviderArn is truthy: src/cli/commands/deploy/actions.ts:287-293 (API key) and 323-331 (OAuth), and src/cli/tui/hooks/useCdkPreflight.ts:819-825 and 864-872. So a 'skipped' credential never reaches deployed-state. The throw the user actually sees is in the CDK construct (consumer): agentcore-l3-cdk-constructs src/cdk/constructs/components/mcp/Gateway.ts:282-284 looks up this.credentials?.[credentialName] and throws `Credential "X" not found in deployed state` when the ARN is missing. The CDK is correctly rejecting incomplete state; the missing-ARN root cause is purely CLI. Note: getOAuth2Provider already exists and is already exported (src/cli/operations/identity/oauth2-credential-provider.ts:122 and index.ts:9); only an analogous getApiKeyProvider must be added.

## The fix
Add a secretless link path in pre-deploy-identity.ts: in the three skip branches, before skipping, attempt to resolve an existing provider's ARN by name (new getApiKeyProvider helper wrapping the existing GetApiKeyCredentialProviderCommand at api-key-credential-provider.ts:54; reuse the already-present getOAuth2Provider for OAuth). On success, return a new status 'linked' carrying credentialProviderArn (and clientSecretArn/callbackUrl for OAuth) so the existing ARN-collection loops persist it to deployed-state.json for CDK wiring. Keep create/update behavior unchanged when a local secret is present. Surface a clear error only when neither a local secret nor a remote provider exists. This is exactly PR #973 (OPEN, +204/-19). Recommendation: review and merge #973; the design decision to settle is the not-found failure mode (error vs continue) — PR makes it fail clearly. Minor: the brief overstates the change set (getOAuth2Provider already exists/exported; OAuth needs wiring, not a new function).

_Files touched:_ src/cli/operations/deploy/pre-deploy-identity.ts (setupApiKeyCredentialProvider skip branch 175-181; setupSingleOAuth2Provider skip branches 405-411 and 415-423); src/cli/operations/identity/api-key-credential-provider.ts (add getApiKeyProvider using GetApiKeyCredentialProviderCommand at line 54); src/cli/operations/identity/index.ts (export getApiKeyProvider; getOAuth2Provider already exported at line 9); src/cli/tui/hooks/useCdkPreflight.ts (handle new 'linked' status ~802/845, ARN collection 819-825/864-872); src/cli/commands/deploy/actions.ts (287-293/323-331). Consumers requiring no change: src/assets/cdk/lib/cdk-stack.ts:100-114 forwards credentials map; agentcore-l3-cdk-constructs src/cdk/constructs/components/mcp/Gateway.ts:282-284 is the throw site (pinned ^0.1.0-alpha.19; the brief's cited Gateway.ts:227-229 is the IAM grant block, not the throw).

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (reverted production source to original, kept new tests): the 6 pass-condition unit tests fail. setupApiKeyCredentialProvider/setupSingleOAuth2Provider return status 'skipped' with NO credentialProviderArn when no local secret exists but a remote provider does (AssertionError: expected 'skipped' to be 'linked'). The secretless+no-remote case returned a silent skip (hasErrors=false -> 'expected false to be true'). getApiKeyProvider did not exist. This is the exact root cause: a 'skipped' result with no ARN is never persisted by the ARN-collection loops in commands/deploy/actions.ts:317-323 and 353-361, so the CDK Gateway throws 'Credential X not found'. AFTER (fix restored): all 33 identity-related tests pass (npx vitest run pre-deploy-identity.test.ts + api-key-credential-provider.test.ts -> Tests 33 passed). (a) no local secret + remote exists -> status 'linked' with non-undefined credentialProviderArn for both API key (new getApiKeyProvider wrapping GetApiKeyCredentialProviderCommand) and OAuth2 (existing getOAuth2Provider carrying clientSecretArn/callbackUrl); the actions.ts loops persist any result with an ARN and hasErrors only trips on status==='error', so 'linked' reaches deployedCredentials. (b) local secret present -> create/update unchanged. (c) no local secret AND no remote -> clear MissingCredentialsError ('...no existing AgentCore Identity ... credential provider named ... was found') with status 'error', no silent skip.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
