### PR TITLE
fix(cli): In browser-mode.ts launchBrowserDev(), replace the inline... (#1376)

### DIFF
--- a/src/cli/commands/dev/__tests__/launch-browser-dev.test.ts
+++ b/src/cli/commands/dev/__tests__/launch-browser-dev.test.ts
@@ -1,0 +1,90 @@
+// Regression test for #1376: launching dev from the interactive `agentcore`
+// menu must render the harness deploy inside the alt-screen DevScreen TUI (the
+// same path `agentcore dev` uses) instead of plain inline console.log lines.
+import type { AgentCoreProjectSpec } from '../../../../schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const harnessOnlyProject = {
+  runtimes: [],
+  harnesses: [{ name: 'my-harness' }],
+} as unknown as AgentCoreProjectSpec;
+
+const { mockRunCliDeploy, mockRunWebUI, mockIsDeploySkippable, mockLoadProjectConfig, mockRender } = vi.hoisted(() => ({
+  mockRunCliDeploy: vi.fn().mockResolvedValue(undefined),
+  mockRunWebUI: vi.fn().mockResolvedValue(undefined),
+  mockIsDeploySkippable: vi.fn(),
+  mockLoadProjectConfig: vi.fn(),
+  mockRender: vi.fn(),
+}));
+
+vi.mock('../../deploy/progress', () => ({ runCliDeploy: mockRunCliDeploy }));
+vi.mock('../../../operations/deploy/change-detection', () => ({ isDeploySkippable: mockIsDeploySkippable }));
+vi.mock('../../../tui/screens/dev/DevScreen', () => ({ DevScreen: 'DevScreen' }));
+vi.mock('../../../tui/context', () => ({ LayoutProvider: 'LayoutProvider' }));
+vi.mock('ink', () => ({ render: (...args: unknown[]) => mockRender(...args) }));
+
+vi.mock('../../../lib', () => ({
+  getWorkingDirectory: () => '/proj',
+  findConfigRoot: () => '/proj',
+  ConfigIO: class {
+    configExists() {
+      return false;
+    }
+  },
+}));
+vi.mock('../../../operations/dev', () => ({
+  loadProjectConfig: mockLoadProjectConfig,
+  getDevSupportedAgents: () => [],
+  getDevConfig: () => undefined,
+  loadDevEnv: vi.fn().mockResolvedValue({ envVars: {} }),
+}));
+vi.mock('../../../operations/dev/otel', () => ({
+  startOtelCollector: vi.fn().mockResolvedValue({ collector: undefined, otelEnvVars: {} }),
+}));
+vi.mock('../../../operations/dev/web-ui', () => ({ runWebUI: mockRunWebUI }));
+
+import { launchBrowserDev } from '../browser-mode';
+
+/** Drive the rendered DevScreen by invoking the prop callback the picker passes. */
+function driveDevScreen(invoke: (props: Record<string, unknown>) => void): void {
+  mockRender.mockImplementation((element: { props: { children: { props: Record<string, unknown> } } }) => {
+    // Defer so the picker's `unmount` binding is initialized before the callback runs.
+    const exited = Promise.resolve().then(() => invoke(element.props.children.props));
+    return { unmount: vi.fn(), waitUntilExit: () => exited };
+  });
+}
+
+describe('launchBrowserDev (#1376 entry-path consistency)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadProjectConfig.mockResolvedValue(harnessOnlyProject);
+  });
+
+  afterEach(() => {
+    mockRender.mockReset();
+  });
+
+  it('shows the alt-screen DevScreen TUI for a harness deploy instead of inline runCliDeploy', async () => {
+    mockIsDeploySkippable.mockResolvedValue(false);
+    driveDevScreen(props => (props.onLaunchBrowser as (s: unknown) => void)({ harnessName: 'my-harness' }));
+
+    await launchBrowserDev();
+
+    expect(mockRunCliDeploy).not.toHaveBeenCalled();
+    expect(mockRender).toHaveBeenCalledOnce();
+    expect(mockRunWebUI).toHaveBeenCalledOnce();
+    const webUiArgs = mockRunWebUI.mock.calls[0]?.[0] as { serverOptions: { selectedHarness?: string } };
+    expect(webUiArgs.serverOptions.selectedHarness).toBe('my-harness');
+  });
+
+  it('returns early without launching the web UI when the picker is cancelled', async () => {
+    mockIsDeploySkippable.mockResolvedValue(false);
+    // Picker resolves with no selection (waitUntilExit resolves, onLaunchBrowser never fires).
+    driveDevScreen(() => undefined);
+
+    await launchBrowserDev();
+
+    expect(mockRunCliDeploy).not.toHaveBeenCalled();
+    expect(mockRunWebUI).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/dev/browser-mode.ts
+++ b/src/cli/commands/dev/browser-mode.ts
@@ -15,7 +15,6 @@ import { listMemoryRecords, retrieveMemoryRecords } from '../../operations/memor
 import { loadDeployedProjectConfig, resolveAgentOrHarness } from '../../operations/resolve-agent';
 import { fetchTraceRecords, listTraces } from '../../operations/traces';
 import { LayoutProvider } from '../../tui/context';
-import { runCliDeploy } from '../deploy/progress';
 import { render } from 'ink';
 import path from 'node:path';
 import React from 'react';
@@ -133,14 +132,30 @@ export async function launchBrowserDev(): Promise<void> {
     process.exit(1);
   }
 
-  // Only auto-deploy for harness-only projects, and skip if no CDK changes
-  if (hasHarnesses && !hasRuntimes && !(await isDeploySkippable())) {
-    await runCliDeploy();
-  }
-
   const configRoot = findConfigRoot(workingDir);
   const persistTracesDir = path.join(configRoot ?? workingDir, '.cli', 'traces');
   const { collector, otelEnvVars } = await startOtelCollector(persistTracesDir);
+
+  // Only auto-deploy for harness-only projects, and skip if no CDK changes.
+  // Show deploy progress inside the alt-screen DevScreen TUI (the same path
+  // `agentcore dev` uses) instead of plain inline console output, so both
+  // entry points render identically.
+  if (hasHarnesses && !hasRuntimes && !(await isDeploySkippable())) {
+    const pickerResult = await launchTuiDevScreenWithPicker(workingDir);
+    if (pickerResult == null) {
+      return;
+    }
+    await runBrowserMode({
+      workingDir,
+      project,
+      port: 8080,
+      agentName: pickerResult.agentName,
+      harnessName: pickerResult.harnessName,
+      otelEnvVars,
+      collector,
+    });
+    return;
+  }
 
   await runBrowserMode({
     workingDir,


### PR DESCRIPTION
Refs aws/agentcore-cli#1376

## Issues
- **#1376** — In preview builds, launching dev via the interactive `agentcore` menu and selecting "dev" renders the harness deploy as plain inline spinner/console.log lines in the normal terminal buffer, whereas running `agentcore dev` directly takes over the screen with the full alt-screen DevScreen TUI. Same deploy, two inconsistent looks depending on entry path. Cosmetic only — deployment functions identically either way; preview-gated so GA users are unaffected.

## Root cause
Two divergent CLI render paths for the same harness deploy: interactive menu (render.ts:70-73 -> launchBrowserDev -> runCliDeploy inline spinner at progress.ts:46-90, no alt screen) vs direct `agentcore dev` (command.tsx:514 -> launchTuiDevScreenWithPicker alt-screen DevScreen). Both call the same handleDeploy; only the wrapper differs. Introduced by bed1de0f (#1341), confirmed via git blame -L 136,138.

## The fix
In browser-mode.ts launchBrowserDev(), replace the inline `if (hasHarnesses) { await runCliDeploy(); }` (lines 136-138) with launchTuiDevScreenWithPicker(workingDir) — the same alt-screen TUI picker the direct `agentcore dev` command uses (command.tsx:514) — then route the picker result into runBrowserMode (passing agentName/harnessName, otelEnvVars, collector) or return early if the user cancels (pickerResult == null). No extra isPreviewEnabled() gate is needed inside the block since the surrounding hasHarnesses already includes it (line 129); GA/non-preview behavior is unchanged. This is exactly what OPEN PR #1410 (Closes #1376, ~22-line change in browser-mode.ts + tests) does on branch fix/dev-tui-consistency-1376-main; the earlier PR #1409 was closed/superseded. Track PR #1410 to merge — it is not yet an ancestor of v0.20.2.

_Files touched:_ src/cli/commands/dev/browser-mode.ts launchBrowserDev() lines 136-138 (the inline `await runCliDeploy()`) — replace with launchTuiDevScreenWithPicker() + runBrowserMode routing, per PR #1410. Reference paths: src/cli/tui/render.ts:70-73 (interactive-menu entry via exit action 'dev'), src/cli/commands/dev/command.tsx:513-533 (the correct TUI path), src/cli/commands/deploy/progress.ts:46-90 (the inline spinner renderer), src/cli/tui/screens/dev/DevScreen.tsx + src/cli/tui/hooks/useDevDeploy.ts (the structured alt-screen deploy UI).

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (original buggy code, git HEAD): launchBrowserDev() called `await runCliDeploy()` inline for harness-only projects needing a deploy, so the interactive `agentcore` menu -> "dev" path (render.ts:70-72 -> launchBrowserDev) printed plain white console.log lines ("Deploying project resources...", spinner) into normal terminal scrollback with no alt-screen takeover, while `agentcore dev` direct (command.tsx:522-526) showed the contained alt-screen DevScreen box. I proved the buggy behavior is what the regression test guards: temporarily re-introduced the inline `runCliDeploy()` and the new test FAILED ("expected vi.fn() not to be called, actually called 1 times" on mockRunCliDeploy; render never invoked). AFTER (fix/1376): browser-mode.ts removes the runCliDeploy import + inline call (grep count of runCliDeploy in file = 0); launchBrowserDev() now calls launchTuiDevScreenWithPicker(workingDir) at line 144, routes the non-null pickerResult into runBrowserMode({agentName, harnessName,...}) and returns early when pickerResult==null. tui-harness reproduction: built CLI at dist/cli/index.mjs, created harness-only scratch project (runtimes:[], 1 harness, undeployed => isDeploySkippable=false), launched interactive `agentcore` menu via tui-harness, selected "dev". The deploy rendered INSIDE the alt-screen DevScreen TUI (bufferType: alternate) as a contained box: header "Dev", "Deploying project resources..." with step-by-step [done] markers (Load deployment target / Validate proje

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
