### PR TITLE
fix(cli): Populate the runtime invoke URL for AWS_IAM agents in `ag... (#1593)

### DIFF
--- a/src/cli/operations/fetch-access/__tests__/fetch-runtime-access.test.ts
+++ b/src/cli/operations/fetch-access/__tests__/fetch-runtime-access.test.ts
@@ -1,0 +1,49 @@
+import { fetchRuntimeAccess } from '../fetch-runtime-access';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../lib', () => ({
+  ConfigIO: vi.fn(),
+}));
+
+const RUNTIME_ARN = 'arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/my-agent-abc123';
+const EXPECTED_URL = `https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/${encodeURIComponent(RUNTIME_ARN)}/invocations`;
+
+const deployedState = {
+  targets: {
+    default: {
+      resources: {
+        runtimes: {
+          'my-agent': { runtimeId: 'rt-1', runtimeArn: RUNTIME_ARN, roleArn: 'arn:aws:iam::123:role/r' },
+        },
+      },
+    },
+  },
+};
+
+const projectSpec = {
+  runtimes: [{ name: 'my-agent', authorizerType: 'AWS_IAM' }],
+  credentials: [],
+};
+
+const awsTargets = [{ name: 'default', region: 'us-east-1', account: '123456789012' }];
+
+function createMockConfigIO() {
+  return {
+    readDeployedState: vi.fn().mockResolvedValue(deployedState),
+    readProjectSpec: vi.fn().mockResolvedValue(projectSpec),
+    readAWSDeploymentTargets: vi.fn().mockResolvedValue(awsTargets),
+  } as any;
+}
+
+describe('fetchRuntimeAccess', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns the runtime invocation URL and SigV4 message for an AWS_IAM agent, with no token', async () => {
+    const result = await fetchRuntimeAccess('my-agent', { configIO: createMockConfigIO() });
+
+    expect(result.url).toBe(EXPECTED_URL);
+    expect(result.authType).toBe('AWS_IAM');
+    expect(result.token).toBeUndefined();
+    expect(result.message).toContain('SigV4');
+  });
+});

--- a/src/cli/operations/fetch-access/fetch-runtime-access.ts
+++ b/src/cli/operations/fetch-access/fetch-runtime-access.ts
@@ -1,0 +1,78 @@
+import { ConfigIO } from '../../../lib';
+import { buildRuntimeInvocationUrl } from '../../commands/status/constants';
+import { fetchOAuthToken } from './oauth-token';
+import type { TokenFetchResult } from './types';
+
+/**
+ * Resolve invoke access for a deployed agent runtime.
+ *
+ * AWS_IAM agents have no token to fetch (SigV4 signing is used instead) but DO have an
+ * invoke URL, so we surface the runtime invocation URL plus a SigV4 message — parity with
+ * the AWS_IAM gateway path. CUSTOM_JWT agents additionally fetch an OAuth access token.
+ */
+export async function fetchRuntimeAccess(
+  agentName: string,
+  options: { configIO?: ConfigIO; deployTarget?: string; identityName?: string } = {}
+): Promise<TokenFetchResult> {
+  const configIO = options.configIO ?? new ConfigIO();
+
+  const deployedState = await configIO.readDeployedState();
+  const projectSpec = await configIO.readProjectSpec();
+  const awsTargets = await configIO.readAWSDeploymentTargets();
+
+  const targetNames = Object.keys(deployedState.targets);
+  if (targetNames.length === 0) {
+    throw new Error('No deployed targets found. Run `agentcore deploy` first.');
+  }
+
+  const targetName = options.deployTarget ?? targetNames[0]!;
+  const target = deployedState.targets[targetName];
+  if (!target) {
+    throw new Error(`Deployment target '${targetName}' not found. Available targets: ${targetNames.join(', ')}`);
+  }
+
+  const agentSpec = projectSpec.runtimes.find(a => a.name === agentName);
+  if (!agentSpec) {
+    const available = projectSpec.runtimes.map(a => a.name);
+    throw new Error(`Agent '${agentName}' not found in project. Available agents: ${available.join(', ') || 'none'}`);
+  }
+
+  const deployedRuntime = target.resources?.runtimes?.[agentName];
+  if (!deployedRuntime?.runtimeArn) {
+    throw new Error(`Agent '${agentName}' does not have a deployed runtime. Run \`agentcore deploy\` first.`);
+  }
+
+  const region = awsTargets.find(t => t.name === targetName)?.region;
+  const url = region ? buildRuntimeInvocationUrl(region, deployedRuntime.runtimeArn) : '';
+
+  const authType = agentSpec.authorizerType ?? 'AWS_IAM';
+
+  if (authType === 'AWS_IAM') {
+    return {
+      url,
+      authType: 'AWS_IAM',
+      message: 'This agent uses AWS_IAM authentication. Use AWS SigV4 signing to invoke.',
+    };
+  }
+
+  const jwtConfig = agentSpec.authorizerConfiguration?.customJwtAuthorizer;
+  if (!jwtConfig) {
+    throw new Error(`Agent '${agentName}' is configured as CUSTOM_JWT but has no customJwtAuthorizer configuration.`);
+  }
+
+  const result = await fetchOAuthToken({
+    resourceName: agentName,
+    jwtConfig,
+    deployedState,
+    targetName,
+    credentials: projectSpec.credentials,
+    credentialName: options.identityName,
+  });
+
+  return {
+    url,
+    authType: 'CUSTOM_JWT',
+    token: result.token,
+    expiresIn: result.expiresIn,
+  };
+}

--- a/src/cli/operations/fetch-access/index.ts
+++ b/src/cli/operations/fetch-access/index.ts
@@ -1,5 +1,6 @@
 export { fetchGatewayToken } from './fetch-gateway-token';
 export { canFetchHarnessToken, fetchHarnessToken } from './fetch-harness-token';
+export { fetchRuntimeAccess } from './fetch-runtime-access';
 export { canFetchRuntimeToken, fetchRuntimeToken } from './fetch-runtime-token';
 export { fetchOAuthToken } from './oauth-token';
 export type { OAuthTokenResult } from './oauth-token';

--- a/src/cli/tui/screens/fetch-access/useFetchAccessFlow.ts
+++ b/src/cli/tui/screens/fetch-access/useFetchAccessFlow.ts
@@ -4,7 +4,7 @@ import type { OAuthTokenResult, ResourceInfo, TokenFetchResult } from '../../../
 import {
   fetchGatewayToken,
   fetchHarnessToken,
-  fetchRuntimeToken,
+  fetchRuntimeAccess,
   listAgents,
   listGateways,
   listHarnesses,
@@ -13,8 +13,8 @@ import { spawn } from 'node:child_process';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
- * Resolve token-bearing access for an agent runtime or harness. AWS_IAM resources have no token
- * to fetch (SigV4 signing is used instead); CUSTOM_JWT resources fetch an OAuth token directly,
+ * Resolve token-bearing access for a harness. AWS_IAM harnesses have no token to fetch
+ * (SigV4 signing is used instead); CUSTOM_JWT harnesses fetch an OAuth token directly,
  * with any error (missing credential, bad config) surfacing in the error phase.
  */
 async function fetchTokenAccess(
@@ -127,7 +127,7 @@ export function useFetchAccessFlow() {
         ? fetchGatewayToken(resource.name)
         : resource.resourceType === 'harness'
           ? fetchTokenAccess(resource, fetchHarnessToken)
-          : fetchTokenAccess(resource, fetchRuntimeToken);
+          : fetchRuntimeAccess(resource.name);
 
     fetchToken
       .then(result => {


### PR DESCRIPTION
Refs aws/agentcore-cli#1593

## Issues
- **#1593** — `agentcore fetch access` lists IAM-authenticated agents and gateways in the resource picker, then on selecting an IAM agent shows only "Auth: IAM" plus a SigV4 message — no token (expected, IAM has none) and, worse, no invoke URL and no example command, because the IAM agent path hard-codes url:''. Users see resources they expect to "fetch" only to be told there is nothing to fetch. Cosmetic/UX friction; the resources still work via SigV4.

## Root cause
By design, the list functions return all deployed resources including IAM ones. listAgents pushes every deployed runtime and defaults authType to 'AWS_IAM' (src/cli/operations/fetch-access/list-agents.ts:25-28); listGateways includes AWS_IAM gateways (list-gateways.ts:27-31), which list-gateways.test.ts:60-64 asserts as intended ('gw-iam' returned). useFetchAccessFlow.ts:64-67 merges both into one picker; FetchAccessScreen.tsx:108-119 renders them with [IAM] labels (authLabel line 13). On selecting an IAM AGENT, fetchAgentAccess returns url:'' + SigV4 message + no token (useFetchAccessFlow.ts:9-15); the empty url suppresses the URL block (FetchAccessScreen.tsx:159) and Example block (line 208), so the result screen is near-empty. IAM GATEWAYS fare better — fetch-gateway-token.ts:51-56 returns a non-empty gatewayUrl, so the URL + `aws curl` example DO render (the strictly-degraded case is the IAM agent). Code introduced by #657 (runtime inbound auth) atop the fetch command from #627; unchanged and unfixed at v0.20.2. No PR/commit references #1593. Entire trace is local CLI code reading ConfigIO; no backend call reached on the IAM path.

## The fix
Design decision required. Option (a): filter AWS_IAM resources out of the picker (skip authType==='AWS_IAM' in useFetchAccessFlow.ts:64-67 or in list-agents/list-gateways) — but this hides legitimate resources users may still want the invoke URL for, and would require updating list-gateways.test.ts and the non-interactive availableGateways path in action.ts:24-31. Option (b, recommended): keep IAM resources but make selection useful — populate the runtime invoke URL for IAM agents instead of url:'' (useFetchAccessFlow.ts:10) so the URL + `aws curl` example render exactly as the IAM-gateway path already does, and optionally dim/annotate IAM rows in the picker (FetchAccessScreen.tsx:117) as "SigV4, no token". Option (b) brings the agent path to parity with the gateway path and is the higher-value, low-risk fix. CLI-only, small.

_Files touched:_ src/cli/tui/screens/fetch-access/useFetchAccessFlow.ts:8-15,64-67; src/cli/tui/screens/fetch-access/FetchAccessScreen.tsx:108-119,159,208-219; src/cli/operations/fetch-access/list-agents.ts:21-29; src/cli/operations/fetch-access/list-gateways.ts:23-43; src/cli/operations/fetch-access/fetch-gateway-token.ts:51-56 (reference for parity); and src/cli/commands/fetch/action.ts:22-40 if IAM filtering (option a) is chosen. Tests: src/cli/operations/fetch-access/__tests__/list-gateways.test.ts.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE: On HEAD, useFetchAccessFlow.ts routed runtime selection through fetchTokenAccess(resource, fetchRuntimeToken), whose AWS_IAM branch hard-coded `url: ''` (lines 24-29). I proved this with a throwaway repro test mirroring the original branch: result.url === '' and, per FetchAccessScreen.tsx gating (`{result.url && ...}` at lines ~161 URL block and ~210 Example block), both blocks are suppressed (urlBlock=false, exampleBlock=false) — the dead-end the issue reports. By contrast the AWS_IAM *gateway* test (fetch-gateway-token.test.ts:124-136) asserts a populated url=GATEWAY_URL, which is why that path renders usefully — confirming the IAM agent was the strictly-degraded case.

AFTER: The fix adds src/cli/operations/fetch-access/fetch-runtime-access.ts (fetchRuntimeAccess) which reads deployed runtimeArn + targetConfig.region and builds the URL via the existing buildRuntimeInvocationUrl(region, runtimeArn) (status/constants.ts:18). useFetchAccessFlow.ts now routes runtime selection to fetchRuntimeAccess(resource.name). New unit test fetch-runtime-access.test.ts (mock ConfigIO with runtimeArn+region) PASSES: result.url === 'https://bedrock-agentcore.us-east-1.amazonaws.com/runtimes/<URL-encoded arn>/invocations', result.authType === 'AWS_IAM', result.token === undefined, message contains 'SigV4'. With url populated, FetchAccessScreen renders the URL block and the `aws curl <url>/` AWS_IAM Example block — parity with the gateway path, no token shown (correct for IAM).

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
