### PR TITLE
fix(unit-only): Primarily a DX/discoverability fix (stateless behavior is... (#1591)

### DIFF
--- a/src/cli/commands/invoke/__tests__/command.test.ts
+++ b/src/cli/commands/invoke/__tests__/command.test.ts
@@ -1,6 +1,6 @@
 // Tests for invoke CLI mode — exitCode propagation and flag validation
 import { handleInvoke } from '../action.js';
-import { registerInvoke } from '../command.js';
+import { printInvokeResult, registerInvoke } from '../command.js';
 import { resolvePrompt } from '../resolve-prompt.js';
 import { Command } from '@commander-js/extra-typings';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -144,5 +144,30 @@ describe('invoke CLI mode — exitCode propagation', () => {
     expect(out).toContain('--additional-params must be a valid JSON object');
     // In --json mode the error must NOT go to console.error (would break JSON consumers).
     expect(erred.join('')).not.toContain('--additional-params');
+  });
+});
+
+describe('printInvokeResult resume hint', () => {
+  let erred: string[];
+
+  beforeEach(() => {
+    erred = [];
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => erred.push(args.join(' ')));
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('suppresses the "To resume" hint when the target has no memory', () => {
+    printInvokeResult({ success: true, response: 'hi', sessionId: 'abc', hasMemory: false }, {});
+    expect(erred.join('\n')).toContain('Session: abc');
+    expect(erred.join('\n')).not.toContain('To resume');
+  });
+
+  it('shows the "To resume" hint when the target has memory', () => {
+    printInvokeResult({ success: true, response: 'hi', sessionId: 'abc', hasMemory: true }, {});
+    expect(erred.join('\n')).toContain('To resume: agentcore invoke --session-id abc');
   });
 });

--- a/src/cli/commands/invoke/action.ts
+++ b/src/cli/commands/invoke/action.ts
@@ -48,6 +48,11 @@ export async function loadInvokeConfig(configIO: ConfigIO = new ConfigIO()): Pro
 export async function handleInvoke(context: InvokeContext, options: InvokeOptions = {}): Promise<InvokeResult> {
   const { project, deployedState, awsTargets } = context;
 
+  // Session continuity only exists when memory is configured: the no-memory
+  // template is stateless per turn, so re-invoking with the same --session-id
+  // resumes nothing. Drives whether the "To resume" hint is shown downstream.
+  const hasMemory = (project.memories?.length ?? 0) > 0;
+
   // Gateway invoke: route through a deployed gateway
   if (options.gateway) {
     const targetNames = Object.keys(deployedState.targets);
@@ -669,6 +674,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
           targetName: selectedTargetName,
           response,
           sessionId: aguiResult.sessionId,
+          hasMemory,
           logFilePath: logger.logFilePath,
         };
       }
@@ -679,6 +685,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
         targetName: selectedTargetName,
         response,
         sessionId: aguiResult.sessionId,
+        hasMemory,
         logFilePath: logger.logFilePath,
       };
     } catch (err) {
@@ -733,6 +740,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
         targetName: selectedTargetName,
         response: fullResponse,
         sessionId: result.sessionId,
+        hasMemory,
         logFilePath: logger.logFilePath,
       };
     } catch (err) {
@@ -764,6 +772,7 @@ export async function handleInvoke(context: InvokeContext, options: InvokeOption
     targetName: selectedTargetName,
     response: response.content,
     sessionId: response.sessionId,
+    hasMemory,
     logFilePath: logger.logFilePath,
   };
 }

--- a/src/cli/commands/invoke/command.tsx
+++ b/src/cli/commands/invoke/command.tsx
@@ -93,17 +93,24 @@ export function redactSensitiveText(value: string): string {
   );
 }
 
-function printInvokeResult(result: InvokeResult, options: InvokeOptions): void {
+export function printInvokeResult(result: InvokeResult, options: InvokeOptions): void {
+  // Resume continuity only works when the target has memory; without it the
+  // agent is stateless per turn, so promising "To resume" would be misleading.
+  const printSession = (): void => {
+    if (!result.sessionId) return;
+    console.error(`\nSession: ${result.sessionId}`);
+    if (result.hasMemory) {
+      console.error(`To resume: agentcore invoke --session-id ${result.sessionId}`);
+    }
+  };
+
   if (options.json) {
     const serialized = serializeResult(result);
     if (typeof serialized.response === 'string') serialized.response = redactSensitiveText(serialized.response);
     if (typeof serialized.error === 'string') serialized.error = redactSensitiveText(serialized.error);
     console.log(JSON.stringify(serialized));
   } else if (options.stream) {
-    if (result.sessionId) {
-      console.error(`\nSession: ${result.sessionId}`);
-      console.error(`To resume: agentcore invoke --session-id ${result.sessionId}`);
-    }
+    printSession();
     if (result.logFilePath) {
       console.error(`Log: ${result.logFilePath}`);
     }
@@ -113,10 +120,7 @@ function printInvokeResult(result: InvokeResult, options: InvokeOptions): void {
     } else if (!result.success && result.error) {
       console.error(redactSensitiveText(result.error.message));
     }
-    if (result.sessionId) {
-      console.error(`\nSession: ${result.sessionId}`);
-      console.error(`To resume: agentcore invoke --session-id ${result.sessionId}`);
-    }
+    printSession();
     if (result.logFilePath) {
       console.error(`Log: ${result.logFilePath}`);
     }
@@ -141,7 +145,10 @@ export const registerInvoke = (program: Command) => {
     .option('--gateway <name>', 'Invoke through a gateway [non-interactive]')
     .option('--gateway-target-name <name>', 'HTTP runtime target on the gateway [non-interactive]')
     .option('--target <name>', 'Select deployment target [non-interactive]')
-    .option('--session-id <id>', 'Use specific session ID for conversation continuity')
+    .option(
+      '--session-id <id>',
+      'Use a specific session ID (groups turns; continuity requires memory — see `agentcore add memory`)'
+    )
     .option('--user-id <id>', 'User ID for runtime invocation (default: "default-user")')
     .option('--json', 'Output as JSON [non-interactive]')
     .option('--stream', 'Stream response in real-time (TUI streams by default) [non-interactive]')

--- a/src/cli/commands/invoke/types.ts
+++ b/src/cli/commands/invoke/types.ts
@@ -81,4 +81,10 @@ export type InvokeResult = Result & {
   response?: string;
   sessionId?: string;
   exitCode?: number;
+  /**
+   * True when the resolved target has memory configured. Without memory the
+   * agent is stateless per turn, so re-invoking with the same --session-id
+   * resumes nothing — the "To resume" hint is suppressed in that case.
+   */
+  hasMemory?: boolean;
 };

--- a/src/cli/tui/screens/generate/types.ts
+++ b/src/cli/tui/screens/generate/types.ts
@@ -250,7 +250,7 @@ export function validateDockerfileInput(value: string): true | string {
 }
 
 export const MEMORY_OPTIONS = [
-  { id: 'none', title: 'None', description: 'No memory' },
-  { id: 'shortTerm', title: 'Short-term memory', description: 'Context within a session' },
+  { id: 'none', title: 'None', description: 'No memory - each turn is a fresh, stateless session' },
+  { id: 'shortTerm', title: 'Short-term memory', description: 'Remembers prior turns within a session' },
   { id: 'longAndShortTerm', title: 'Long-term and short-term', description: 'Persists across sessions' },
 ] as const;

--- a/src/cli/tui/screens/invoke/InvokeScreen.tsx
+++ b/src/cli/tui/screens/invoke/InvokeScreen.tsx
@@ -208,12 +208,14 @@ export function InvokeScreen({
   const mcpFetchTriggeredRef = useRef(false);
 
   useEffect(() => {
-    if (sessionId && messages.length > 0) {
+    // Only promise resume when memory is configured — without it the agent is
+    // stateless per turn and re-invoking with the same session ID resumes nothing.
+    if (sessionId && messages.length > 0 && config?.hasMemory) {
       const cyan = '\x1b[36m';
       const reset = '\x1b[0m';
       setExitMessage(`To resume this session, run: ${cyan}agentcore invoke --session-id ${sessionId}${reset}`);
     }
-  }, [sessionId, messages.length]);
+  }, [sessionId, messages.length, config?.hasMemory]);
 
   // Compute auth type early so hooks can reference it
   const totalInvokables = (config?.runtimes.length ?? 0) + (config?.harnesses.length ?? 0);

--- a/src/cli/tui/screens/invoke/useInvokeFlow.ts
+++ b/src/cli/tui/screens/invoke/useInvokeFlow.ts
@@ -64,6 +64,11 @@ export interface InvokeConfig {
   target: AwsDeploymentTarget;
   targetName: string;
   projectName: string;
+  /**
+   * True when the project has memory configured. Without it the agent is
+   * stateless per turn, so the "To resume" exit hint is suppressed.
+   */
+  hasMemory: boolean;
 }
 
 export interface InvokeFlowOptions {
@@ -263,7 +268,14 @@ export function useInvokeFlow(options: InvokeFlowOptions = {}): InvokeFlowState 
             };
           }
 
-          setConfig({ runtimes, harnesses, target: targetConfig, targetName, projectName: project.name });
+          setConfig({
+            runtimes,
+            harnesses,
+            target: targetConfig,
+            targetName,
+            projectName: project.name,
+            hasMemory: (project.memories?.length ?? 0) > 0,
+          });
 
           if (initialHarnessName) {
             const harnessIdx = harnesses.findIndex(h => h.name === initialHarnessName);


### PR DESCRIPTION
Refs aws/agentcore-cli#1591

## Issues
- **#1591** — An agent created with the default memory option ('none') has no session continuity: every invoke behaves like a fresh conversation. The agent never gets a session_manager, so nothing is loaded from or written to a durable store, and the no-memory template uses a single process-global agent that is not keyed by session_id, so --session-id has no effect at all in that path. Meanwhile the CLI tells the user the opposite: --session-id is labeled "Use specific session ID for conversation continuity" and both the CLI stream output and the interactive TUI print "To resume this session, run: agentcore invoke --session-id ..." even for memory-less agents. New customers reasonably expect continuity and are confused when there is none.

## Root cause
Reproduces exactly at HEAD (v0.20.2) and is by-design: session continuity is gated entirely on memory being configured. In src/assets/python/http/strands/base/main.py, the default (memory='none', no truncation, no config-bundle, no payment) renders the branch at lines 441-468: a single module-global _agent created once via get_or_create_agent() with conversation_manager=NullConversationManager() and NO session_manager. Two consequences: (1) with no session_manager, nothing is loaded/persisted to a durable store, so history is lost on container cold-start; (2) the global _agent is NOT keyed by session_id, so the runtime session_id (set as x-amz-bedrock-agentcore-session-id at src/cli/commands/invoke/action.ts:175) is functionally inert in this path — --session-id changes nothing. The session_id is only consumed by src/assets/python/http/strands/capabilities/memory/session.py get_memory_session_manager, which returns None when MEMORY_ID is unset; that manager (SDK AgentCoreMemorySessionManager extending Strands RepositorySessionManager, bedrock-agentcore-sdk-python v1.9.1, src/bedrock_agentcore/memory/integrations/strands/session_manager.py) is the sole mechanism that restores cross-invoke history, and it only exists when hasMemory is true. Memory defaults to 'none' (src/cli/commands/create/command.tsx:285,343,588,608; validate.ts:90; --defaults => "no memory" at command.tsx:394). The 'none' option description is just "No memory" (src/cli/tui/screens/generate/types.ts:253), --session-id is mislabeled "Use specific session ID for conversation continuity" (src/cli/commands/invoke/command.tsx:146), and the unconditional "To resume" notice fires for memory-less agents in both the CLI stream path (command.tsx:105-120) and the TUI (src/cli/tui/screens/invoke/InvokeScreen.tsx:216).

## The fix
Primarily a DX/discoverability fix (stateless behavior is correct without a session store), plus tightening of actively misleading copy. (1) Reword MEMORY_OPTIONS so the tradeoff is explicit: 'none' = "No memory - each turn is a fresh, stateless session", 'shortTerm' = "Remembers prior turns within a session" (src/cli/tui/screens/generate/types.ts:252-256). (2) Make the continuity messaging memory-aware: soften the --session-id help text (command.tsx:146) away from "conversation continuity", and suppress or reword the "To resume --session-id" notice (command.tsx:105-120) and the TUI exit hint (InvokeScreen.tsx:216) when the resolved agent has no memory configured — in the no-memory path --session-id is genuinely inert, so promising resume is wrong, not just vague. (3) Add a post-create/first-invoke hint for memory-less agents pointing to `agentcore add memory`; AddFlow.tsx already renders a memory-aware success note (AddFlow.tsx:370-394, 411-417) so reuse that copy. Product decision required: document/warn (low effort, recommended) vs change the default to short-term memory (larger; provisioning/cost impact). Do NOT change the NullConversationManager branch itself. Optional follow-up: address the latent cross-session-bleed smell of the single non-keyed global _agent in the no-memory path.

_Files touched:_ src/cli/tui/screens/generate/types.ts:252-256 (MEMORY_OPTIONS descriptions); src/cli/commands/invoke/command.tsx:146 (--session-id help) and 105-120 ("To resume" notice, make memory-conditional); src/cli/tui/screens/invoke/InvokeScreen.tsx:216 (TUI resume hint, make memory-conditional); optional post-create hint reusing src/cli/tui/screens/add/AddFlow.tsx:370-394. Template src/assets/python/http/strands/base/main.py NullConversationManager branch (lines 441-468) is correct and should NOT change.

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (base/HEAD): command.tsx:144 help text = 'Use specific session ID for conversation continuity'; printInvokeResult unconditionally emitted 'To resume: agentcore invoke --session-id <id>' in both stream (HEAD:105) and non-stream (HEAD:118) branches regardless of memory; InvokeScreen.tsx:213 unconditionally set 'To resume this session, run: ...' exit hint; MEMORY_OPTIONS descriptions = 'No memory' / 'Context within a session' (never named the stateless tradeoff). AFTER (fix/1591): printInvokeResult only prints the 'To resume:' line when result.hasMemory is true (Session: still always prints); hasMemory derived once in handleInvoke (action.ts:54 = (project.memories?.length ?? 0) > 0) and threaded through all 4 InvokeResult return paths; InvokeScreen exit hint gated on config?.hasMemory (InvokeScreen.tsx:213) with useInvokeFlow populating hasMemory on InvokeConfig; help text reworded to '...continuity requires memory — see `agentcore add memory`'; MEMORY_OPTIONS 'none' -> 'No memory - each turn is a fresh, stateless session', 'shortTerm' -> 'Remembers prior turns within a session'. ADVERSARIAL PROOF: temporarily reverted printInvokeResult to unconditional 'To resume' -> the new no-memory test FAILED (expected '\nSession: abc\nTo resume...' not to contain 'To resume'), confirming the test guards the symptom; restored fix and it passes. REGRESSION GUARD: 'shows the To resume hint when target has memory' test passes. EXPLICITLY-NOT-CHANGED verified: base/main.py untouched, cre

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
