### PR TITLE
fix(surgical): Establish a single source of truth for "this command cann... (#1589)

### DIFF
--- a/src/cli/tui/App.tsx
+++ b/src/cli/tui/App.tsx
@@ -12,6 +12,7 @@ import { DatasetFlow } from './screens/dataset-hub';
 import { DeployScreen } from './screens/deploy/DeployScreen';
 import { EvalHubScreen, EvalScreen } from './screens/eval';
 import { ExportHarnessFlow } from './screens/export';
+import { FeedbackScreen } from './screens/feedback';
 import { FetchAccessScreen } from './screens/fetch-access';
 import { HelpScreen, HomeScreen } from './screens/home';
 import { ImportFlow } from './screens/import';
@@ -80,6 +81,7 @@ type Route =
   | { name: 'dataset' }
   | { name: 'import' }
   | { name: 'export-harness' }
+  | { name: 'feedback' }
   | { name: 'cli-only'; commandId: string };
 
 // Commands that don't require being at the project root
@@ -199,6 +201,8 @@ function AppContent({
         return;
       }
       setRoute({ name: 'export-harness' });
+    } else if (id === 'feedback') {
+      setRoute({ name: 'feedback' });
     }
   };
 
@@ -491,6 +495,10 @@ function AppContent({
         onDeploy={() => setRoute({ name: 'deploy' })}
       />
     );
+  }
+
+  if (route.name === 'feedback') {
+    return <FeedbackScreen onExit={handleBack} />;
   }
 
   if (route.name === 'cli-only') {

--- a/src/cli/tui/__tests__/app-command-coverage.test.ts
+++ b/src/cli/tui/__tests__/app-command-coverage.test.ts
@@ -33,6 +33,7 @@ const ROUTED_COMMANDS = new Set([
   'config-bundle',
   'dataset',
   'batch-evaluations',
+  'feedback',
 ]);
 
 describe('TUI home screen command coverage', () => {
@@ -51,5 +52,20 @@ describe('TUI home screen command coverage', () => {
     }
 
     expect(unhandled).toEqual([]);
+  });
+
+  it('the cliOnly flag and CLI_ONLY_EXAMPLES agree for every visible command', () => {
+    const program = createProgram();
+    const commands = getCommandsForUI(program, { inProject: true });
+
+    // A command can never be in the main interactive list while routing to the
+    // cli-only dead-end: cliOnly is true iff selecting it hits CliOnlyScreen.
+    for (const cmd of commands) {
+      const hasCliOnlyExamples = cmd.id in CLI_ONLY_EXAMPLES;
+      expect(cmd.cliOnly, `${cmd.id}: cliOnly flag must match CLI_ONLY_EXAMPLES membership`).toBe(hasCliOnlyExamples);
+    }
+
+    // feedback is interactive (real FeedbackScreen), not a cli-only dead-end.
+    expect('feedback' in CLI_ONLY_EXAMPLES).toBe(false);
   });
 });

--- a/src/cli/tui/copy.ts
+++ b/src/cli/tui/copy.ts
@@ -135,16 +135,8 @@ export const CLI_ONLY_EXAMPLES: Record<string, { description: string; examples: 
       'agentcore run insights -r MyAgent -i FailureAnalysis --wait',
     ],
   },
-  feedback: {
-    description: 'Send feedback about the AgentCore CLI to the team.',
-    examples: ['agentcore feedback', 'agentcore feedback --screenshot'],
-  },
   config: {
     description: 'Adjust global configuration settings such as telemetry opt-out status.',
     examples: ['agentcore config'],
-  },
-  insights: {
-    description: '[preview] View insights analysis jobs and results.',
-    examples: ['agentcore insights history', 'agentcore insights results --id <id>'],
   },
 };

--- a/src/cli/tui/utils/commands.ts
+++ b/src/cli/tui/utils/commands.ts
@@ -1,3 +1,4 @@
+import { CLI_ONLY_EXAMPLES } from '../copy';
 import type { Command } from '@commander-js/extra-typings';
 
 export interface CommandMeta {
@@ -15,9 +16,13 @@ export interface CommandMeta {
 const HIDDEN_FROM_TUI = ['help', 'telemetry', 'promote'] as const;
 
 /**
- * Commands that are CLI-only (shown but marked as requiring CLI invocation).
+ * Single source of truth for "this top-level command cannot run interactively in
+ * the TUI". Derived from CLI_ONLY_EXAMPLES so the `cliOnly` flag (list placement)
+ * can never diverge from App.tsx's dead-end routing: a command is flagged cliOnly
+ * iff selecting it routes to the CliOnlyScreen. Multi-word keys in CLI_ONLY_EXAMPLES
+ * (e.g. 'run eval') are subcommand paths, not top-level commands, so they never match.
  */
-const CLI_ONLY_COMMANDS = ['traces', 'pause', 'resume', 'stop', 'archive'] as const;
+const CLI_ONLY_COMMANDS = new Set(Object.keys(CLI_ONLY_EXAMPLES));
 
 /**
  * Commands hidden from TUI when inside an existing project.
@@ -53,6 +58,6 @@ export function getCommandsForUI(program: Command, options: GetCommandsOptions =
         .filter(sub => !HIDDEN_SUBCOMMANDS.includes(sub.name() as (typeof HIDDEN_SUBCOMMANDS)[number]))
         .map(sub => sub.name()),
       disabled: false,
-      cliOnly: CLI_ONLY_COMMANDS.includes(cmd.name() as (typeof CLI_ONLY_COMMANDS)[number]),
+      cliOnly: CLI_ONLY_COMMANDS.has(cmd.name()),
     }));
 }


### PR DESCRIPTION
Refs aws/agentcore-cli#1589

## Issues
- **#1589** — In the TUI command list, `feedback` and `config` appear in the MAIN (interactive) command list, but selecting them dead-ends on the "this command runs in the terminal" CliOnlyScreen instead of doing anything. `feedback` is the worst case: it has a real interactive FeedbackScreen the TUI could render, but the TUI tells the user to go run it in the terminal instead. Meanwhile genuinely CLI-only commands behave a third way and preview-gated `export` simply doesn't appear. Net effect is inconsistent, confusing UX across unsupported/partially-supported commands.

## Root cause
Two manually-synced lists have diverged: CLI_ONLY_COMMANDS (commands.ts:20) sets the cliOnly flag that HelpScreen.tsx:232,236 uses for list placement, while CLI_ONLY_EXAMPLES (copy.ts:68) controls App.tsx:138-142 dead-end routing. config (copy.ts:142) and feedback (copy.ts:138) are in the second but not the first and are registered unconditionally (cli.ts:101,122), so they render in the main interactive list (cliOnly=false) yet route to the CliOnlyScreen dead-end. feedback has a real FeedbackScreen (commands/feedback/command.tsx:27) the TUI never reaches. Verified at v0.20.2 by reading all files and running the coverage test (passes, so it does not catch this).

## The fix
Establish a single source of truth for "this command cannot run interactively in the TUI" and reconcile membership, then enforce consistency in tests. Concretely: derive the `cliOnly` flag in commands.ts from the keys of CLI_ONLY_EXAMPLES (or vice versa) so a command can never be in the main list yet dead-end. Then decide membership per the issue author's lean toward hiding: `feedback` should NOT be CLI-only — wire its existing FeedbackScreen (commands/feedback/command.tsx:27) into App.tsx onSelectCommand so it opens interactively; `config` should either get a tiny TUI screen or, at minimum, be flagged cliOnly consistently (or hidden via HIDDEN_FROM_TUI) so it isn't shown-then-dead-ended. Also drop the unused `insights` key from CLI_ONLY_EXAMPLES. Strengthen app-command-coverage.test.ts to assert the two lists agree: every CLI_ONLY_EXAMPLES key that is a registered top-level command must be flagged cliOnly, and every cliOnly command must have examples. Design decision required: hide-all-unsupported vs show-in-CLI-only-section-with-usage; author recommends hide.

_Files touched:_ src/cli/tui/utils/commands.ts (CLI_ONLY_COMMANDS:20, HIDDEN_FROM_TUI:15, cliOnly derivation:56); src/cli/tui/copy.ts (CLI_ONLY_EXAMPLES:68 — feedback:138, config:142, unused insights:146); src/cli/tui/App.tsx (onSelectCommand CLI_ONLY_EXAMPLES branch:138-142, add a feedback route alongside FeedbackScreen); src/cli/tui/screens/home/HelpScreen.tsx (interactive vs cliOnly split:231-237); src/cli/tui/__tests__/app-command-coverage.test.ts (add list-consistency assertion)

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> Drove the actual TUI via tui-harness against the built dist (node /local/home/aidandal/workplace/issues/bugfix-run/clusters/1589/repo/dist/cli/index.mjs).

PASS CONDITION 1 (feedback opens interactive screen): Tab -> command list -> filtered "feedback" -> Enter. AFTER FIX: opens the interactive Ink FeedbackScreen ("Message -> Screenshot -> Consent -> Submitting -> Done" stepper with "Tell us what's on your mind / Feedback" text input). It NO LONGER routes to the generic "this command runs in the terminal" CliOnlyScreen. BEFORE FIX (per symptom + code): feedback was in CLI_ONLY_EXAMPLES so App.tsx:140-142 short-circuited every feedback selection to the cli-only dead-end, while cliOnly=false placed it in the main interactive list.

PASS CONDITION 2 (config consistent): In the main interactive list, "config" is ABSENT. Pressing "/" reveals a separate "CLI only" section containing pause/resume/stop/traces/config/archive. Selecting CLI-only "config" routes to the CliOnlyScreen ("Usage: $ agentcore config"). So config is now flagged cliOnly consistently (CLI-only section AND dead-end route agree) instead of being in the main list while routing to the dead-end.

PASS CONDITION 3 (single source of truth): commands.ts:25 now derives CLI_ONLY_COMMANDS = new Set(Object.keys(CLI_ONLY_EXAMPLES)); the cliOnly flag (HelpScreen list placement) and App.tsx CLI_ONLY_EXAMPLES dead-end routing can no longer diverge.

PASS CONDITION 4 (test fails pre-fix, passes post-fix): Verified empirically.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
