### PR TITLE
fix(cli): Converge dev onto the in-TUI error pattern. DevScreen alr... (#1588)

### DIFF
--- a/src/cli/tui/App.tsx
+++ b/src/cli/tui/App.tsx
@@ -10,6 +10,7 @@ import { ConfigBundleFlow } from './screens/config-bundle-hub';
 import { CreateScreen } from './screens/create';
 import { DatasetFlow } from './screens/dataset-hub';
 import { DeployScreen } from './screens/deploy/DeployScreen';
+import { DevScreen } from './screens/dev/DevScreen';
 import { EvalHubScreen, EvalScreen } from './screens/eval';
 import { ExportHarnessFlow } from './screens/export';
 import { FetchAccessScreen } from './screens/fetch-access';
@@ -52,6 +53,7 @@ type Route =
       autoSession?: boolean;
     }
   | { name: 'logs' }
+  | { name: 'dev' }
   | { name: 'create' }
   | { name: 'add' }
   | { name: 'status' }
@@ -142,9 +144,7 @@ function AppContent({
     }
 
     if (id === 'dev') {
-      setExitAction({ type: 'dev' });
-      exit();
-      return;
+      setRoute({ name: 'dev' });
     } else if (id === 'exec') {
       setExitAction({ type: 'exec' });
       exit();
@@ -269,6 +269,21 @@ function AppContent({
 
   if (route.name === 'logs') {
     return <LogsScreen isInteractive={isInteractive} onExit={handleBack} />;
+  }
+
+  if (route.name === 'dev') {
+    // Render the dev picker in-TUI so agent-less projects get a guided error
+    // screen (Esc to go back) instead of crashing out of the TUI. When agents
+    // exist, the picker hands off to browser dev mode via the exit action.
+    return (
+      <DevScreen
+        onBack={handleBack}
+        onLaunchBrowser={() => {
+          setExitAction({ type: 'dev' });
+          exit();
+        }}
+      />
+    );
   }
 
   if (route.name === 'status') {

--- a/src/cli/tui/screens/dev/__tests__/DevScreen.test.tsx
+++ b/src/cli/tui/screens/dev/__tests__/DevScreen.test.tsx
@@ -1,0 +1,70 @@
+import { DevScreen } from '../DevScreen.js';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { mockLoadProjectConfig, mockGetDevSupportedAgents } = vi.hoisted(() => ({
+  mockLoadProjectConfig: vi.fn(),
+  mockGetDevSupportedAgents: vi.fn(),
+}));
+
+vi.mock('../../../../operations/dev', () => ({
+  loadProjectConfig: mockLoadProjectConfig,
+  getDevSupportedAgents: mockGetDevSupportedAgents,
+  getEndpointUrl: vi.fn(),
+}));
+
+// The dev hooks would otherwise try to spin up a real dev server / deploy.
+vi.mock('../../../hooks/useDevServer', () => ({
+  useDevServer: () => ({
+    logs: [],
+    status: 'idle',
+    isStreaming: false,
+    conversation: [],
+    streamingResponse: null,
+    config: null,
+    configLoaded: true,
+    actualPort: 8080,
+    invoke: vi.fn(),
+    execCommand: vi.fn(),
+    execInContainer: vi.fn(),
+    isContainer: false,
+    clearConversation: vi.fn(),
+    restart: vi.fn(),
+    stop: vi.fn(),
+    logFilePath: undefined,
+    hasUndeployedMemory: false,
+    hasVpc: false,
+    protocol: undefined,
+    mcpTools: [],
+    fetchMcpTools: vi.fn(),
+    showMcpHint: false,
+    a2aAgentCard: undefined,
+    a2aStatus: undefined,
+    fetchAgentCard: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../hooks/useDevDeploy', () => ({
+  useDevDeploy: () => ({ steps: [], deployMessages: [], isComplete: false, error: undefined }),
+}));
+
+const noop = () => undefined;
+
+describe('DevScreen', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  // Regression: selecting "dev" in a project with no agents/harnesses must render
+  // the in-TUI error screen (not crash the TUI out to the shell). See issue #1588.
+  it('renders the in-TUI error when no agents or harnesses are defined', async () => {
+    mockLoadProjectConfig.mockResolvedValue({ runtimes: [], harnesses: [] });
+    mockGetDevSupportedAgents.mockReturnValue([]);
+
+    const onLaunchBrowser = vi.fn();
+    const { lastFrame } = render(<DevScreen onBack={noop} onLaunchBrowser={onLaunchBrowser} />);
+    await new Promise(r => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain('No agents or harnesses defined in project.');
+    expect(onLaunchBrowser).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Refs aws/agentcore-cli#1588

## Issues
- **#1588** — In the TUI menu, selecting "dev" in a project that has no agents/harnesses tears down the TUI and dumps the user back to the shell with a bare "Error: No agents or harnesses defined in project." line and exit code 1. Selecting "logs" in the same no-agent state instead shows a clean in-TUI error and lets the user keep navigating. The error content is correct; only the presentation is inconsistent and jarring (full TUI exit vs. in-app message).

## Root cause
Verified at v0.20.2: TUI dev menu entry (App.tsx:144-147) does setExitAction({type:'dev'})+exit() with no agent pre-check; render.ts:70-74 then calls launchBrowserDev() (browser-mode.ts:119) which does console.error+process.exit(1) at lines 123-126/131-134 for agent-less projects. loadProjectConfig (config.ts:139-157) returns non-null for an existing-but-empty project so the !project guard misses it. logs instead routes to an in-TUI error screen (App.tsx:156-157 -> LogsScreen.tsx:78-83). The standalone `agentcore dev` CLI command throws ValidationError (command.tsx:327-331, caught+printed) and never calls launchBrowserDev, so the raw exit is reachable only via the menu exit-action path.

## The fix
Converge dev onto the in-TUI error pattern. DevScreen already implements a noAgentsError in-TUI screen (DevScreen.tsx:500-518) mirroring LogsScreen; route the menu dev selection through an in-TUI DevScreen path (the launchTuiDevScreenWithPicker mechanism already used by the standalone command at command.tsx:514) instead of setExitAction+exit, so the error renders in-app. Keep browser-mode.ts:123-134 process.exit(1) as a CLI-only backstop. Add a regression test under src/cli/tui/screens/dev/__tests__/ paralleling LogsScreen.test.tsx. Precedent: PR #1575 fixed the same early-exit class for web-search/no-gateway.

_Files touched:_ src/cli/tui/App.tsx:144-147 (dev menu branch — route to in-TUI DevScreen instead of setExitAction+exit); src/cli/commands/dev/browser-mode.ts:123-134 (process.exit(1) guards demoted to CLI-only backstop) and the existing launchTuiDevScreenWithPicker at browser-mode.ts:328; reuse src/cli/tui/screens/dev/DevScreen.tsx:500-518 noAgentsError branch; pattern reference src/cli/tui/screens/logs/LogsScreen.tsx:78-83; new regression test under src/cli/tui/screens/dev/__tests__/ mirroring src/cli/tui/screens/logs/__tests__/LogsScreen.test.tsx

## Validation evidence
The fix was verified by reproducing the original symptom and re-running after the change:

> BEFORE (buggy build, fix stashed, same no-agent project /tmp/acfix-1588-proj/acfix1588 created via `create --no-agent`): TUI main menu -> down to "dev" -> Enter tears down the TUI back to the shell. Final screen is the bare line "Error: No agents or harnesses defined in project." with bufferType flipped from "alternate" to "normal" and tui_close reported exitCode: 1. This is exactly the reported symptom (render.ts:70-72 imports+calls launchBrowserDev, which hits console.error+process.exit(1) at browser-mode.ts:123-134 for agent-less projects).

AFTER (fixed build, App.tsx routes dev menu via setRoute({name:'dev'}) -> in-TUI DevScreen): same steps render the in-app DevScreen error screen while the TUI stays alive (bufferType remains "alternate"): title "Dev Server", "No agents or harnesses defined in project.", "Dev mode requires at least one agent with an entrypoint or a harness.", "Run agentcore add agent to create one.", helpText "Esc quit". Pressing Esc returns to the main Commands menu (TUI not exited, navigation continues). Confirmed parity: selecting "logs" in the same project shows its own in-TUI error ("No runtimes defined in agentcore.json", "Esc back") and likewise stays in-TUI. No bare error line and no exit code 1 from the dev menu action. browser-mode.ts:123-134 process.exit(1) CLI backstop guards remain unchanged.

Test suite: **green**.

---
_Staged on the fork as a draft for human review. Promote to aws/agentcore-cli after vetting._
